### PR TITLE
Fixing the first build on empty workspace.

### DIFF
--- a/src/main/java/hudson/plugins/scm/koji/BuildsSerializer.java
+++ b/src/main/java/hudson/plugins/scm/koji/BuildsSerializer.java
@@ -12,7 +12,6 @@ import java.io.OutputStreamWriter;
 import java.io.Reader;
 import java.io.Writer;
 import java.lang.ref.SoftReference;
-import java.util.Optional;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.Marshaller;
 
@@ -33,14 +32,14 @@ public class BuildsSerializer {
         }
     }
 
-    public Optional<Build> read(File file) {
+    public Build read(File file) {
         if (!file.exists() || !file.isFile() || file.length() < 1) {
-            return Optional.empty();
+            return null;
         }
         try (Reader reader = new InputStreamReader(new BufferedInputStream(new FileInputStream(file)), "UTF-8")) {
             Object result = jaxbContext().createUnmarshaller().unmarshal(reader);
             if (result == null || result instanceof Build) {
-                return Optional.of((Build) result);
+                return (Build) result;
             }
             // if we are still here - something went wrong:
             throw new RuntimeException("Deserialization expected Build but got: " + result);

--- a/src/main/java/hudson/plugins/scm/koji/KojiChangeLogParser.java
+++ b/src/main/java/hudson/plugins/scm/koji/KojiChangeLogParser.java
@@ -7,15 +7,13 @@ import hudson.scm.ChangeLogSet;
 import hudson.scm.RepositoryBrowser;
 import java.io.File;
 import java.io.IOException;
-import java.util.Optional;
 import org.xml.sax.SAXException;
 
 public class KojiChangeLogParser extends ChangeLogParser {
 
     @Override
     public ChangeLogSet<? extends ChangeLogSet.Entry> parse(Run run, RepositoryBrowser<?> browser, File changelogFile) throws IOException, SAXException {
-        Optional<Build> buildOpt = new BuildsSerializer().read(changelogFile);
-        Build build = buildOpt.get();
+        Build build = new BuildsSerializer().read(changelogFile);
         return new KojiChangeLogSet(build, run, browser);
     }
 

--- a/src/main/java/hudson/plugins/scm/koji/KojiRevisionFromBuild.java
+++ b/src/main/java/hudson/plugins/scm/koji/KojiRevisionFromBuild.java
@@ -5,15 +5,14 @@ import hudson.plugins.scm.koji.model.Build;
 import hudson.remoting.VirtualChannel;
 import java.io.File;
 import java.io.IOException;
-import java.util.Optional;
 import org.jenkinsci.remoting.RoleChecker;
 
-public class KojiRevisionFromBuild implements FilePath.FileCallable<Optional<Build>> {
+public class KojiRevisionFromBuild implements FilePath.FileCallable<Build> {
 
     @Override
-    public Optional<Build> invoke(File workspace, VirtualChannel channel) throws IOException, InterruptedException {
-        Optional<Build> buildOpt = new BuildsSerializer().read(new File(workspace, "changelog.xml"));
-        return buildOpt;
+    public Build invoke(File workspace, VirtualChannel channel) throws IOException, InterruptedException {
+        Build build = new BuildsSerializer().read(new File(workspace, "changelog.xml"));
+        return build;
     }
 
     @Override

--- a/src/main/java/hudson/plugins/scm/koji/KojiSCM.java
+++ b/src/main/java/hudson/plugins/scm/koji/KojiSCM.java
@@ -24,7 +24,6 @@ import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -142,9 +141,8 @@ public class KojiSCM extends SCM {
         LOG.info("Calculating revision for project '{}' from build: {}", run.getParent().getName(), run.getNumber());
         KojiRevisionFromBuild worker = new KojiRevisionFromBuild();
         FilePath buildWorkspace = new FilePath(run.getRootDir());
-        Optional<Build> buildOpt = buildWorkspace.act(worker);
-        if (buildOpt.isPresent()) {
-            Build build = buildOpt.get();
+        Build build = buildWorkspace.act(worker);
+        if (build != null) {
             LOG.info("Got revision from build {}: {}", run.getNumber(), build.getNvr());
             return new KojiRevisionState(build);
         }

--- a/src/main/java/hudson/plugins/scm/koji/client/KojiBuildDownloader.java
+++ b/src/main/java/hudson/plugins/scm/koji/client/KojiBuildDownloader.java
@@ -16,7 +16,6 @@ import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.List;
-import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.jenkinsci.remoting.RoleChecker;
@@ -36,17 +35,16 @@ public class KojiBuildDownloader implements FilePath.FileCallable<KojiBuildDownl
     @Override
     public KojiBuildDownloadResult invoke(File workspace, VirtualChannel channel) throws IOException, InterruptedException {
         File checkoutBuildFile = new File(workspace, BUILD_XML);
-        Optional<Build> buildOpt = new BuildsSerializer().read(checkoutBuildFile);
-        if (!buildOpt.isPresent()) {
+        Build build = new BuildsSerializer().read(checkoutBuildFile);
+        if (build == null) {
             // if we are here - it is the first build ever,
             // have to pull the koji and download whatever we'll find:
-            Build build = new KojiListBuilds(config, notProcessedNvrPredicate).invoke(workspace, channel);
+            build = new KojiListBuilds(config, notProcessedNvrPredicate).invoke(workspace, channel);
             if (build == null) {
                 // if we are here - no remote changes on first build, exiting:
                 return null;
             }
         }
-        Build build = buildOpt.get();
         // we got the build info in workspace, downloading:
         File targetDir = workspace;
         if (config.getDownloadDir() != null && config.getDownloadDir().length() > 0) {


### PR DESCRIPTION
Previous changeset when removing the use of Optional introduced the failure on the first build or empty workspace. This commit fixes the issue.