### PR TITLE
Making GlobPredicate usable on slave.

### DIFF
--- a/src/main/java/hudson/plugins/scm/koji/KojiSCM.java
+++ b/src/main/java/hudson/plugins/scm/koji/KojiSCM.java
@@ -27,6 +27,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.slf4j.Logger;
@@ -164,10 +165,10 @@ public class KojiSCM extends SCM {
         File processedNvrFile = new File(job.getRootDir(), PROCESSED_BUILDS_HISTORY);
         if (processedNvrFile.exists()) {
             if (processedNvrFile.isFile() && processedNvrFile.canRead()) {
-                Set<String> nvrsSet = Files
-                        .lines(processedNvrFile.toPath(), StandardCharsets.UTF_8)
-                        .collect(Collectors.toSet());
-                return new NotProcessedNvrPredicate(nvrsSet);
+                try (Stream<String> stream = Files.lines(processedNvrFile.toPath(), StandardCharsets.UTF_8)) {
+                    Set<String> nvrsSet = stream.collect(Collectors.toSet());
+                    return new NotProcessedNvrPredicate(nvrsSet);
+                }
             } else {
                 throw new IOException("Processed NVRs is not readable: " + processedNvrFile.getAbsolutePath());
             }

--- a/src/main/java/hudson/plugins/scm/koji/client/GlobPredicate.java
+++ b/src/main/java/hudson/plugins/scm/koji/client/GlobPredicate.java
@@ -4,7 +4,7 @@ import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
-public class GlobPredicate implements Predicate<CharSequence> {
+public class GlobPredicate implements Predicate<CharSequence>, java.io.Serializable {
 
     private final String globExpr;
     private final Pattern globPattern;
@@ -172,6 +172,6 @@ public class GlobPredicate implements Predicate<CharSequence> {
     private static boolean isGlobMeta(char c) {
         return globMetaChars.indexOf(c) != -1;
     }
-    private static char EOL = 0;  //TBD
+    private static final char EOL = 0;  //TBD
 
 }

--- a/src/main/java/hudson/plugins/scm/koji/client/KojiListBuilds.java
+++ b/src/main/java/hudson/plugins/scm/koji/client/KojiListBuilds.java
@@ -76,8 +76,9 @@ public class KojiListBuilds implements FilePath.FileCallable<Build> {
         if (buildOpt.isPresent()) {
             Build build = buildOpt.get();
             new BuildsSerializer().write(build, new File(workspace, BUILD_XML));
+            return build;
         }
-        return buildOpt.get();
+        return null;
     }
 
     private Stream<Build> listMatchingBuilds() {


### PR DESCRIPTION
During the previous test the exclusion field was empty, so missed the exception on GlobPredicate serialization. This should fix it.