### PR TITLE
Archives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target/
 /nbproject/
+.idea/
+*.iml

--- a/src/main/java/hudson/plugins/scm/koji/Constants.java
+++ b/src/main/java/hudson/plugins/scm/koji/Constants.java
@@ -16,19 +16,21 @@ abstract public class Constants {
     public static final String packageID = "packageID";
     public static final String listTags = "listTags";
     public static final String listRPMs = "listRPMs";
+    public static final String listArchives = "listArchives";
     public static final String buildID = "buildID";
     public static final String arches = "arches";
     public static final String build = "build";
     public static final String name = "name";
     public static final String rpms = "rpms";
     public static final String nvr = "nvr";
-    public static final String completion_time = "completion_time";    
+    public static final String completion_time = "completion_time";
     public static final String build_id = "build_id";
     public static final String version = "version";
     public static final String release = "release";
     public static final String arch = "arch";
-    
-       public static final DateTimeFormatter DTF = new DateTimeFormatterBuilder()
+    public static final String filename = "filename";
+
+    public static final DateTimeFormatter DTF = new DateTimeFormatterBuilder()
             .appendValue(ChronoField.YEAR, 4)
             .appendLiteral('-')
             .appendValue(ChronoField.MONTH_OF_YEAR, 2)

--- a/src/main/java/hudson/plugins/scm/koji/client/KojiListBuilds.java
+++ b/src/main/java/hudson/plugins/scm/koji/client/KojiListBuilds.java
@@ -196,23 +196,23 @@ public class KojiListBuilds implements FilePath.FileCallable<Build> {
         String[] arches = composeArchesArray();
         paramsMap.put("__starstar", Boolean.TRUE);
 
-        Object res = execute(Constants.listArchives, paramsMap);
-        if (res != null && (res instanceof Object[]) && ((Object[]) res).length > 0) {
-            for (Object r : (Object[]) res) {
-                if (r != null && r instanceof Map) {
+        Object listedArchives = execute(Constants.listArchives, paramsMap);
+        if (listedArchives != null && (listedArchives instanceof Object[])) {
+            for (Object archive : (Object[]) listedArchives) {
+                if (archive != null && archive instanceof Map) {
                     for (String arch : arches) {
-                        Map<String, Object> rpms = (Map) r;
+                        Map<String, Object> rpms = (Map) archive;
                         rpms.put(Constants.name, m.get(Constants.name));
                         rpms.put(Constants.version, m.get(Constants.version));
                         rpms.put(Constants.release, m.get(Constants.release));
                         rpms.put(Constants.arch, arch);
-                        rpms.put(Constants.nvr, ((Map) r).get(Constants.filename));
-                        rpms.put(Constants.filename, ((Map) r).get(Constants.filename));
+                        rpms.put(Constants.nvr, ((Map) archive).get(Constants.filename));
+                        rpms.put(Constants.filename, ((Map) archive).get(Constants.filename));
                     }
                 }
             }
 
-            m.put(Constants.rpms, res);
+            m.put(Constants.rpms, listedArchives);
         }
 
         return o;
@@ -407,8 +407,7 @@ public class KojiListBuilds implements FilePath.FileCallable<Build> {
         }
 
         @Override
-        public TypeParser getParser(XmlRpcStreamConfig pConfig, NamespaceContextImpl pContext, String pURI, String
-                pLocalName) {
+        public TypeParser getParser(XmlRpcStreamConfig pConfig, NamespaceContextImpl pContext, String pURI, String pLocalName) {
             switch (pLocalName) {
                 case "nil":
                     return new NilParser();

--- a/src/main/java/hudson/plugins/scm/koji/client/KojiListBuilds.java
+++ b/src/main/java/hudson/plugins/scm/koji/client/KojiListBuilds.java
@@ -7,6 +7,7 @@ import hudson.plugins.scm.koji.model.Build;
 import hudson.plugins.scm.koji.model.KojiScmConfig;
 import hudson.plugins.scm.koji.model.RPM;
 import hudson.remoting.VirtualChannel;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
@@ -23,6 +24,7 @@ import java.util.StringTokenizer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
 import org.apache.ws.commons.util.NamespaceContextImpl;
 import org.apache.xmlrpc.client.XmlRpcClient;
 import org.apache.xmlrpc.client.XmlRpcClientConfigImpl;
@@ -30,6 +32,7 @@ import org.apache.xmlrpc.common.TypeFactoryImpl;
 import org.apache.xmlrpc.common.XmlRpcController;
 import org.apache.xmlrpc.common.XmlRpcStreamConfig;
 import org.apache.xmlrpc.parser.AtomicParser;
+import org.apache.xmlrpc.parser.ObjectArrayParser;
 import org.apache.xmlrpc.parser.TypeParser;
 import org.apache.xmlrpc.serializer.I4Serializer;
 import org.apache.xmlrpc.serializer.TypeSerializer;
@@ -40,7 +43,9 @@ import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
 
 import static hudson.plugins.scm.koji.Constants.BUILD_XML;
+import static hudson.plugins.scm.koji.Constants.arch;
 import static hudson.plugins.scm.koji.KojiSCM.DESCRIPTOR;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,9 +67,6 @@ public class KojiListBuilds implements FilePath.FileCallable<Build> {
     public Build invoke(File workspace, VirtualChannel channel) throws IOException, InterruptedException {
         Stream<Build> results = listMatchingBuilds();
 
-//        List<Build> l = results
-//                .filter(b -> notProcessedNvrPredicate.test(b.getNvr()))
-//                .collect(Collectors.toList());
         Optional<Build> buildOpt = results
                 .filter(b -> notProcessedNvrPredicate.test(b.getNvr()))
                 .findFirst();
@@ -108,6 +110,7 @@ public class KojiListBuilds implements FilePath.FileCallable<Build> {
                 .filter(this::filterByTags)
                 // getting rpms and filtering by arch right away:
                 .map(this::retrieveRPMs)
+                .map(this::retrieveArchives)
                 .filter(this::filterByArch)
                 // do not go too far away into the past:
                 .limit(config.getMaxPreviousBuilds())
@@ -175,6 +178,46 @@ public class KojiListBuilds implements FilePath.FileCallable<Build> {
         return o;
     }
 
+    /**
+     * Archives are stored under {@link Constants#rpms} key, together with RPMs.
+     * <p>
+     * Name, Version and Release are not received with info about archive. We need to get it from the build. Arch is
+     * taken from configuration and is later used to compose filepath. Unlike with RPMs, filename is received here so
+     * we can store it.
+     */
+    private Object retrieveArchives(Object o) {
+        if (!(o instanceof Map)) {
+            throw new RuntimeException("Map instance expected, got: " + o);
+        }
+        Map m = (Map) o;
+
+        Map<String, Object> paramsMap = new HashMap<>();
+        paramsMap.put(Constants.buildID, m.get(Constants.build_id));
+        String[] arches = composeArchesArray();
+        paramsMap.put("__starstar", Boolean.TRUE);
+
+        Object res = execute(Constants.listArchives, paramsMap);
+        if (res != null && (res instanceof Object[]) && ((Object[]) res).length > 0) {
+            for (Object r : (Object[]) res) {
+                if (r != null && r instanceof Map) {
+                    for (String arch : arches) {
+                        Map<String, Object> rpms = (Map) r;
+                        rpms.put(Constants.name, m.get(Constants.name));
+                        rpms.put(Constants.version, m.get(Constants.version));
+                        rpms.put(Constants.release, m.get(Constants.release));
+                        rpms.put(Constants.arch, arch);
+                        rpms.put(Constants.nvr, ((Map) r).get(Constants.filename));
+                        rpms.put(Constants.filename, ((Map) r).get(Constants.filename));
+                    }
+                }
+            }
+
+            m.put(Constants.rpms, res);
+        }
+
+        return o;
+    }
+
     private boolean filterByArch(Object o) {
         if (!(o instanceof Map)) {
             throw new RuntimeException("Map instance expected, got: " + o);
@@ -201,13 +244,13 @@ public class KojiListBuilds implements FilePath.FileCallable<Build> {
                 m.get(Constants.nvr),
                 dateKojiToIso(m.get(Constants.completion_time)),
                 Arrays
-                .stream((Object[]) ((Map) o).get(Constants.rpms))
-                .map(this::toRPM)
-                .collect(Collectors.toList()),
+                        .stream((Object[]) ((Map) o).get(Constants.rpms))
+                        .map(this::toRPM)
+                        .collect(Collectors.toList()),
                 Arrays
-                .stream((Object[]) ((Map) o).get("tags"))
-                .map(t -> ((Map<String, String>) t).get(Constants.name))
-                .collect(Collectors.toSet()), null
+                        .stream((Object[]) ((Map) o).get("tags"))
+                        .map(t -> ((Map<String, String>) t).get(Constants.name))
+                        .collect(Collectors.toSet()), null
         );
     }
 
@@ -221,7 +264,8 @@ public class KojiListBuilds implements FilePath.FileCallable<Build> {
                 m.get(Constants.version),
                 m.get(Constants.release),
                 m.get(Constants.nvr),
-                m.get(Constants.arch));
+                m.get(Constants.arch),
+                m.get(Constants.filename));
     }
 
     private String dateKojiToIso(String kojiDate) {
@@ -363,7 +407,8 @@ public class KojiListBuilds implements FilePath.FileCallable<Build> {
         }
 
         @Override
-        public TypeParser getParser(XmlRpcStreamConfig pConfig, NamespaceContextImpl pContext, String pURI, String pLocalName) {
+        public TypeParser getParser(XmlRpcStreamConfig pConfig, NamespaceContextImpl pContext, String pURI, String
+                pLocalName) {
             switch (pLocalName) {
                 case "nil":
                     return new NilParser();

--- a/src/main/java/hudson/plugins/scm/koji/model/KojiScmConfig.java
+++ b/src/main/java/hudson/plugins/scm/koji/model/KojiScmConfig.java
@@ -66,4 +66,19 @@ public class KojiScmConfig implements java.io.Serializable {
         return maxPreviousBuilds;
     }
 
+    @Override
+    public String toString() {
+        return "KojiScmConfig{" +
+                "kojiTopUrl='" + kojiTopUrl + '\'' +
+                ", kojiDownloadUrl='" + kojiDownloadUrl + '\'' +
+                ", packageName='" + packageName + '\'' +
+                ", arch='" + arch + '\'' +
+                ", tag='" + tag + '\'' +
+                ", excludeNvr='" + excludeNvr + '\'' +
+                ", downloadDir='" + downloadDir + '\'' +
+                ", cleanDownloadDir=" + cleanDownloadDir +
+                ", dirPerNvr=" + dirPerNvr +
+                ", maxPreviousBuilds=" + maxPreviousBuilds +
+                '}';
+    }
 }

--- a/src/main/java/hudson/plugins/scm/koji/model/RPM.java
+++ b/src/main/java/hudson/plugins/scm/koji/model/RPM.java
@@ -4,6 +4,7 @@ import hudson.plugins.scm.koji.Constants;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
+import java.util.Optional;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 public class RPM implements java.io.Serializable {
@@ -18,13 +19,16 @@ public class RPM implements java.io.Serializable {
     private final String nvr;
     @XmlElement(name = Constants.arch)
     private final String arch;
+    @XmlElement(name = Constants.filename)
+    private final String filename;
 
-    public RPM(String name, String version, String release, String nvr, String arch) {
+    public RPM(String name, String version, String release, String nvr, String arch, String filename) {
         this.name = name;
         this.version = version;
         this.release = release;
         this.nvr = nvr;
         this.arch = arch;
+        this.filename = filename;
     }
 
     public RPM() {
@@ -33,6 +37,7 @@ public class RPM implements java.io.Serializable {
         this.release = null;
         this.nvr = null;
         this.arch = null;
+        this.filename = null;
     }
 
     public String getName() {
@@ -61,7 +66,7 @@ public class RPM implements java.io.Serializable {
     }
 
     public String getFilename(String suffix) {
-        return nvr + '.' + arch + "." + suffix;
+        return Optional.ofNullable(filename).orElse(nvr + '.' + arch + "." + suffix);
     }
 
 }

--- a/src/test/java/hudson/plugins/scm/koji/client/KojiListBuildsTest.java
+++ b/src/test/java/hudson/plugins/scm/koji/client/KojiListBuildsTest.java
@@ -214,6 +214,21 @@ public class KojiListBuildsTest {
         );
     }
 
+    KojiScmConfig createConfigWindows() {
+        return new KojiScmConfig(
+                "https://brewhub.engineering.redhat.com/brewhub",
+                "http://download.eng.bos.redhat.com/brewroot/packages/",
+                "openjdk8-win",
+                "win",
+                "openjdk-win*",
+                null,
+                null,
+                false,
+                false,
+                10
+        );
+    }
+
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
@@ -382,4 +397,10 @@ public class KojiListBuildsTest {
         assertNotNull(build);
     }
 
+    @Test
+    public void testListMatchingBuildsWindows() throws Exception {
+        KojiListBuilds worker = new KojiListBuilds(createConfigWindows(), new NotProcessedNvrPredicate(new HashSet<>()));
+        Build build = worker.invoke(temporaryFolder.newFolder(), null);
+        assertNotNull(build);
+    }
 }


### PR DESCRIPTION
Support for archives. Archives are listed with xmlrpc method "listArchives" and collected together with RPMs. Added filename field to RPM, which is used if present (archives). If not, logic is same as before.