### PR TITLE
Non existing product

### DIFF
--- a/fake-koji/src/main/java/org/fakekoji/xmlrpc/server/FakeKojiDB.java
+++ b/fake-koji/src/main/java/org/fakekoji/xmlrpc/server/FakeKojiDB.java
@@ -80,8 +80,8 @@ public class FakeKojiDB {
                 return project.hashCode();
             }
         }
-        throw new RuntimeException("Unknown project " + requestedProject + ". Tried: " + trayed + ".");
-
+        ServerLogger.log("Unknown project " + requestedProject + ". Tried: " + trayed + ".");
+        return null;
     }
 
     /*

--- a/fake-koji/src/main/java/org/fakekoji/xmlrpc/server/KojiXmlRpcServer.java
+++ b/fake-koji/src/main/java/org/fakekoji/xmlrpc/server/KojiXmlRpcServer.java
@@ -33,6 +33,7 @@ import org.apache.xmlrpc.XmlRpcHandler;
 import org.apache.xmlrpc.XmlRpcRequest;
 import org.apache.xmlrpc.server.XmlRpcHandlerMapping;
 import org.apache.xmlrpc.server.XmlRpcNoSuchHandlerException;
+import org.apache.xmlrpc.server.XmlRpcServerConfigImpl;
 import org.apache.xmlrpc.webserver.WebServer;
 
 /**
@@ -82,6 +83,10 @@ public class KojiXmlRpcServer {
     public void start() throws IOException {
         webServer = new WebServer(port);
         webServer.setParanoid(false);
+        XmlRpcServerConfigImpl config = new XmlRpcServerConfigImpl();
+        config.setEnabledForExtensions(true);
+        webServer.getXmlRpcServer().setConfig(config);
+
         XmlRpcHandlerMapping xxx = new XmlRpcHandlerMapping() {
             @Override
             /**

--- a/jenkins-scm-koji-plugin/src/test/java/hudson/plugins/scm/koji/client/KojiJenkinsTest.java
+++ b/jenkins-scm-koji-plugin/src/test/java/hudson/plugins/scm/koji/client/KojiJenkinsTest.java
@@ -151,4 +151,45 @@ public class KojiJenkinsTest {
         String shellString = "! find . | grep \".*tarxz\"";
         runTest(config, shellString, false);
     }
+
+    @Test
+    public void testMultiproductWithOneNotExisting() throws Exception {
+        /* Test koji scm plugin on multi-product build with non-existing build
+           -> should end with success */
+        KojiScmConfig config = new KojiScmConfig(
+                "http://localhost:" + JavaServerConstants.xPortAxiom + "/RPC2",
+                "http://localhost:" + JavaServerConstants.dPortAxiom,
+                "non-existing-build java-1.8.0-openjdk",
+                "x86_64,src",
+                "fastdebug-f24*",
+                null,
+                null,
+                false,
+                false,
+                10
+        );
+        String shellString = "find . | grep \"java-1.8.0-openjdk.*x86_64.tarxz\"\n"
+                + "find . | grep \"java-1.8.0-openjdk.*src.tarxz\"";
+        runTest(config, shellString, true);
+    }
+
+    @Test
+    public void testMultiproductWithNoExisting() throws Exception {
+        /* Test koji scm plugin on multi-product build with no existing build
+           -> should end with failure */
+        KojiScmConfig config = new KojiScmConfig(
+                "http://localhost:" + JavaServerConstants.xPortAxiom + "/RPC2",
+                "http://localhost:" + JavaServerConstants.dPortAxiom,
+                "non-existing-build also-not-existing-build",
+                "x86_64,src",
+                "fastdebug-f24*",
+                null,
+                null,
+                false,
+                false,
+                10
+        );
+        String shellString = "! find . | grep \".*tarxz\"";
+        runTest(config, shellString, false);
+    }
 }

--- a/jenkins-scm-koji-plugin/src/test/java/hudson/plugins/scm/koji/client/KojiListBuildsTest.java
+++ b/jenkins-scm-koji-plugin/src/test/java/hudson/plugins/scm/koji/client/KojiListBuildsTest.java
@@ -19,6 +19,7 @@ import org.fakekoji.JavaServer;
 import org.fakekoji.xmlrpc.server.core.FakeKojiTestUtil;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assume.assumeTrue;
 import org.junit.BeforeClass;
 
@@ -281,8 +282,8 @@ public class KojiListBuildsTest {
 
     KojiScmConfig createMultiProductConfig() {
         return new KojiScmConfig(
-                "http://hydra.brq.redhat.com:XPORT/RPC2/",
-                "http://hydra.brq.redhat.com:DPORT/",
+                "https://koji.fedoraproject.org/kojihub",
+                "https://kojipkgs.fedoraproject.org/packages/",
                 "java-1.7.0-openjdk java-1.8.0-openjdk java-9-openjdk",
                 null,
                 "*",
@@ -527,5 +528,31 @@ public class KojiListBuildsTest {
         KojiListBuilds worker = new KojiListBuilds(createMultiProductConfig(), new NotProcessedNvrPredicate(new ArrayList<>()));
         Build build = worker.invoke(temporaryFolder.newFolder(), null);
         assertNotNull(build);
+    }
+
+    @Test
+    public void testMultiproductBuildsWithNonExistingProduct() throws IOException, InterruptedException {
+        assumeTrue(onRhNet);
+        KojiScmConfig config = new KojiScmConfig(
+                "https://koji.fedoraproject.org/kojihub",
+                "https://kojipkgs.fedoraproject.org/packages/",
+                "this_package_name_hopefully_does_not_exist java-1.8.0-openjdk",
+                null, "*", null, null, false, false, 10);
+        KojiListBuilds worker = new KojiListBuilds(config, new NotProcessedNvrPredicate(new ArrayList<>()));
+        Build build = worker.invoke(temporaryFolder.newFolder(), null);
+        assertNotNull(build);
+    }
+
+    @Test
+    public void testNonExistingBuilds() throws IOException, InterruptedException {
+        assumeTrue(onRhNet);
+        KojiScmConfig config = new KojiScmConfig(
+                "https://koji.fedoraproject.org/kojihub",
+                "https://kojipkgs.fedoraproject.org/packages/",
+                "some_random_package_name_that_does_not_exist some_other_package_that_hopefully_also_does_not_exist",
+                null, "*", null, null, false, false, 10);
+        KojiListBuilds worker = new KojiListBuilds(config, new NotProcessedNvrPredicate(new ArrayList<>()));
+        Build build = worker.invoke(temporaryFolder.newFolder(), null);
+        assertNull(build);
     }
 }

--- a/koji-scm-lib/src/main/java/hudson/plugins/scm/koji/client/BuildMatcher.java
+++ b/koji-scm-lib/src/main/java/hudson/plugins/scm/koji/client/BuildMatcher.java
@@ -117,6 +117,9 @@ public class BuildMatcher {
 
     private List<Object> listPackageBuilds(String packageName) {
         Integer packageId = (Integer) execute(Constants.getPackageID, packageName);
+        if (packageId == null) {
+            return Collections.emptyList();
+        }
 
         Map paramsMap = new HashMap();
         paramsMap.put(Constants.packageID, packageId);


### PR DESCRIPTION
Koji method `getPackageID` returns `null` in case of non-existing package. fake-koji did throw `RuntimeException`. This patch narrows fake-koji API to match the Koji.

jenkins-koji-plugin was not ready for null value, so this patch handle this case producing empty list which is then handled in streams, thus no other changes needed.