### PR TITLE
FakeBuild uses project mapping api to determine expected build arches

### DIFF
--- a/fake-koji/src/main/java/org/fakekoji/JavaServer.java
+++ b/fake-koji/src/main/java/org/fakekoji/JavaServer.java
@@ -60,7 +60,7 @@ public class JavaServer {
 
     public JavaServer(AccessibleSettings settings) throws UnknownHostException, MalformedURLException {
         this.settings = settings;
-        kojiXmlRpcServer = new KojiXmlRpcServer(settings.getDbFileRoot(), settings.getRealXPort());
+        kojiXmlRpcServer = new KojiXmlRpcServer(settings);
         kojiDownloadServer = new KojiDownloadServer(settings.getDbFileRoot(), settings.getRealDPort());
         previewFakeKojiServer = new PreviewFakeKoji(settings);
         sshApiServer = new SshApiService(settings.getDbFileRoot(), settings.getRealUPort());

--- a/fake-koji/src/main/java/org/fakekoji/http/ProjectMapping.java
+++ b/fake-koji/src/main/java/org/fakekoji/http/ProjectMapping.java
@@ -10,7 +10,7 @@ import java.util.stream.Collectors;
 
 import static org.fakekoji.http.ProjectMappingExceptions.*;
 
-class ProjectMapping {
+public class ProjectMapping {
 
     private final AccessibleSettings settings;
 
@@ -104,7 +104,7 @@ class ProjectMapping {
         throw new ProjectDoesNotMatchException();
     }
 
-    List<String> getExpectedArchesOfProject(String project) throws ProjectMappingException {
+    public List<String> getExpectedArchesOfProject(String project) throws ProjectMappingException {
         File expectedArchesFile = null;
         for (File file : Objects.requireNonNull(getProjectFile(project).listFiles())) {
             if (file.getName().equals(FakeBuild.archesConfigFileName)) {
@@ -127,7 +127,7 @@ class ProjectMapping {
         return Arrays.asList(arches);
     }
 
-    List<String> getExpectedArchesOfNVR(String nvr) throws ProjectMappingException{
+    public List<String> getExpectedArchesOfNVR(String nvr) throws ProjectMappingException{
         return getExpectedArchesOfProject(getProjectOfNvra(nvr));
     }
 

--- a/fake-koji/src/main/java/org/fakekoji/http/ProjectMappingExceptions.java
+++ b/fake-koji/src/main/java/org/fakekoji/http/ProjectMappingExceptions.java
@@ -1,8 +1,8 @@
 package org.fakekoji.http;
 
-class ProjectMappingExceptions {
+public class ProjectMappingExceptions {
 
-    static class ProjectMappingException extends Exception {
+    public static class ProjectMappingException extends Exception {
 
         ProjectMappingException(String message) {
             super(message);

--- a/fake-koji/src/main/java/org/fakekoji/xmlrpc/server/FakeKojiDB.java
+++ b/fake-koji/src/main/java/org/fakekoji/xmlrpc/server/FakeKojiDB.java
@@ -32,6 +32,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import org.fakekoji.http.AccessibleSettings;
 import org.fakekoji.xmlrpc.server.core.FakeBuild;
 import org.fakekoji.xmlrpc.server.utils.DirFilter;
 
@@ -42,14 +44,14 @@ import org.fakekoji.xmlrpc.server.utils.DirFilter;
  */
 public class FakeKojiDB {
 
-    private final File mainDir;
     private final String[] projects;
     private final List<FakeBuild> builds;
+    private final AccessibleSettings settings;
 
-    FakeKojiDB(File file) {
+    FakeKojiDB(AccessibleSettings settings) {
         ServerLogger.log(new Date().toString() + " (re)initizing fake koji DB");
-        mainDir = file;
-        File[] projectDirs = mainDir.listFiles(new DirFilter());
+        this.settings = settings;
+        File[] projectDirs = settings.getDbFileRoot().listFiles(new DirFilter());
         projects = new String[projectDirs.length];
         builds = new ArrayList<>();
         //read all projects
@@ -61,7 +63,7 @@ public class FakeKojiDB {
             for (File version : versions) {
                 File[] releases = version.listFiles(new DirFilter());
                 for (File release : releases) {
-                    FakeBuild b = new FakeBuild(projectDir.getName(), version.getName(), release.getName(), release);
+                    FakeBuild b = new FakeBuild(projectDir.getName(), version.getName(), release.getName(), release, settings.getProjectMapping());
                     builds.add(b);
                 }
             }

--- a/fake-koji/src/main/java/org/fakekoji/xmlrpc/server/KojiXmlRpcServer.java
+++ b/fake-koji/src/main/java/org/fakekoji/xmlrpc/server/KojiXmlRpcServer.java
@@ -24,7 +24,6 @@
 package org.fakekoji.xmlrpc.server;
 
 import hudson.plugins.scm.koji.Constants;
-import java.io.File;
 import java.io.IOException;
 import java.util.Date;
 import java.util.Map;
@@ -35,6 +34,7 @@ import org.apache.xmlrpc.server.XmlRpcHandlerMapping;
 import org.apache.xmlrpc.server.XmlRpcNoSuchHandlerException;
 import org.apache.xmlrpc.server.XmlRpcServerConfigImpl;
 import org.apache.xmlrpc.webserver.WebServer;
+import org.fakekoji.http.AccessibleSettings;
 
 /**
  * This Server implements Koji XmlRpc API (It is called by jenkins koji plugin )
@@ -43,14 +43,12 @@ import org.apache.xmlrpc.webserver.WebServer;
  */
 public class KojiXmlRpcServer {
 
-    private final File dbFileRoot;
-    private final int port;
     private WebServer webServer;
+    AccessibleSettings settings;
 
-    public KojiXmlRpcServer(File dbFileRoot, int port) {
-        this.dbFileRoot = dbFileRoot;
-        this.port = port;
-        this.webServer = new WebServer(port);
+    public KojiXmlRpcServer(AccessibleSettings settings) {
+        this.settings = settings;
+        this.webServer = new WebServer(settings.getRealXPort());
     }
 
     /**
@@ -76,11 +74,11 @@ public class KojiXmlRpcServer {
     }
 
     public int getPort() {
-        return port;
+        return settings.getRealXPort();
     }
 
     public void start() throws IOException {
-        webServer = new WebServer(port);
+        webServer = new WebServer(settings.getRealXPort());
         webServer.setParanoid(false);
         XmlRpcServerConfigImpl config = new XmlRpcServerConfigImpl();
         config.setEnabledForExtensions(true);
@@ -97,7 +95,7 @@ public class KojiXmlRpcServer {
                     public Object execute(XmlRpcRequest xrr) throws XmlRpcException {
                         ServerLogger.log(new Date().toString() + " Requested: " + xrr.getMethodName());
                         //need reinitializzing, as new  build couldbe added
-                        FakeKojiDB kojiDb = new FakeKojiDB(dbFileRoot);
+                        FakeKojiDB kojiDb = new FakeKojiDB(settings);
                         if (xrr.getMethodName().equals("sample.sum")) {
                             //testing method
                             return sum(xrr.getParameter(0), xrr.getParameter(1));


### PR DESCRIPTION
api gets expected arches from arches-expected file located in each project's directory (see ProjectMapping class). If the file doesn't exists, hardcoded values in FakeBuild class are used.