### PR TITLE
Remove Object, Map of Objects and Map of Map instances and use actual…

### DIFF
--- a/fake-koji/src/main/java/org/fakekoji/JavaServer.java
+++ b/fake-koji/src/main/java/org/fakekoji/JavaServer.java
@@ -111,7 +111,7 @@ public class JavaServer {
         int realUPort = DFAULT_SSHUPLOAD_PORT;
         int realJport = DEFAULT_JENKINS_PORT;
         String hostname = null;
-        int view1Port = 8000;
+        int view1Port = 80;
         File dbFileRoot = null;
         File reposFileRoot = null;
 

--- a/fake-koji/src/main/java/org/fakekoji/JavaServer.java
+++ b/fake-koji/src/main/java/org/fakekoji/JavaServer.java
@@ -111,7 +111,7 @@ public class JavaServer {
         int realUPort = DFAULT_SSHUPLOAD_PORT;
         int realJport = DEFAULT_JENKINS_PORT;
         String hostname = null;
-        int view1Port = 80;
+        int view1Port = 8000;
         File dbFileRoot = null;
         File reposFileRoot = null;
 

--- a/fake-koji/src/main/java/org/fakekoji/xmlrpc/server/FakeKojiDB.java
+++ b/fake-koji/src/main/java/org/fakekoji/xmlrpc/server/FakeKojiDB.java
@@ -23,17 +23,16 @@
  */
 package org.fakekoji.xmlrpc.server;
 
-import hudson.plugins.scm.koji.Constants;
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
+import hudson.plugins.scm.koji.model.Build;
+import hudson.plugins.scm.koji.model.RPM;
 import org.fakekoji.http.AccessibleSettings;
-import org.fakekoji.http.ProjectMappingExceptions;
 import org.fakekoji.xmlrpc.server.core.FakeBuild;
 import org.fakekoji.xmlrpc.server.utils.DirFilter;
 
@@ -73,80 +72,37 @@ public class FakeKojiDB {
     }
 
     Integer getPkgId(String requestedProject) {
-        String trayed = "";
+        StringBuilder triedProjects = new StringBuilder();
         for (String project : projects) {
-            trayed += " " + project;
+            triedProjects.append(" ").append(project);
             if (project.equals(requestedProject)) {
                 //is there better str->int function?
                 //indeed, the file. But number of projects is small.
                 return project.hashCode();
             }
         }
-        ServerLogger.log("Unknown project " + requestedProject + ". Tried: " + trayed + ".");
+        ServerLogger.log("Unknown project " + requestedProject + ". Tried: " + triedProjects + ".");
         return null;
     }
 
-    /*
-     Return is scary Object[] where mebers are hashmaps
-         "size = 21"	HashMap	ObjectVariable 	
-    [ 0]	"start_ts => 1.47013406794314E9"	 	
-    [ 2]	"owner_name => jvanek"	 	
-    [ 3]	"completion_time => 2016-08-02 21:23:37.487583"	 	
-    [ 4]	"volume_id => 0"	 	
-    [ 5]	"owner_id => 1487"	 	
-    [ 6]	"release => 3.b14.fc26"	 	
-    [ 7]	"volume_name => DEFAULT"	 	
-    [ 8]	"task_id => 15101251"	 	
-    [ 9]	"epoch => 1"	 	
-    [10]	"nvr => java-1.8.0-openjdk-1.8.0.101-3.b14.fc26"	 	
-    [11]	"package_id => 15685"	 	
-    [12]	"creation_event_id => 17490426"	 	
-    [13]	"version => 1.8.0.101"	 	
-    [14]	"start_time => 2016-08-02 10:34:27.943136"	 	
-    [15]	"build_id => 787467"	 	
-    [16]	"package_name => java-1.8.0-openjdk"	 	
-    [17]	"name => java-1.8.0-openjdk"	 	
-    [18]	"creation_ts => 1.47013406794314E9"	 	
-    [19]	"completion_ts => 1.47017301748758E9"	 	
-    [20]	"state => 1"	 	
-    [ 1]	"creation_time => 2016-08-02 10:34:27.943136"	 	
-     */
-    Object[] getProjectBuildsByProjectIdAsMaps(Integer projectId) {
-        List<FakeBuild> matchingBuilds = getProjectBuildsByProjectId(projectId);
-        for (int i = 0; i < matchingBuilds.size(); i++) {
-            FakeBuild get = matchingBuilds.get(i);
-            boolean mayBeFailed = new IsFailedBuild(get.getDir()).reCheck().getLastResult();
-            if (mayBeFailed) {
-                ServerLogger.log("Removing build (" + i + "): " + get.toString() + " from result. Contains FAILED records");
-                matchingBuilds.remove(i);
-                i--;
+    List<Build> getProjectBuilds(Integer projectId) {
+        List<Build> projectBuilds = new ArrayList<>();
+        for (FakeBuild build : builds) {
+            if (build.getProjectID() == projectId) {
+                if (new IsFailedBuild(build.getDir()).reCheck().getLastResult()) {
+                    ServerLogger.log("Removing build " + build.toString() + " from result. Contains FAILED records");
+                    continue;
+                }
+                projectBuilds.add(build.toBuild());
             }
         }
-        Object[] res = new Object[matchingBuilds.size()];
-        for (int i = 0; i < matchingBuilds.size(); i++) {
-            FakeBuild get = matchingBuilds.get(i);
-            res[i] = get.toBuildMap();
-
-        }
-        return res;
-    }
-
-    List<FakeBuild> getProjectBuildsByProjectId(Integer projectId) {
-        List<FakeBuild> res = new ArrayList(builds.size());
-        for (int i = 0; i < builds.size(); i++) {
-            FakeBuild get = builds.get(i);
-            if (get.getProjectID() == projectId) {
-                res.add(get);
-            }
-        }
-        return res;
+        return projectBuilds;
     }
 
     FakeBuild getBuildById(Integer buildId) {
-        for (int i = 0; i < builds.size(); i++) {
-            FakeBuild get = builds.get(i);
-            if (get.getBuildID() == buildId) {
-                return get;
+        for (FakeBuild build : builds) {
+            if (build.getBuildID() == buildId) {
+                return build;
             }
         }
         return null;
@@ -157,37 +113,19 @@ public class FakeKojiDB {
      * that if the build is for some os only, it should be tagged accodringly.
      * On contrary, if it is static, then it should pass anywhere
      *
-     * @param parameter
-     * @return
+     * @param buildId Integer
+     * @return set of strings
      */
-    Object[] getTags(Map parameter) {
-        Integer buildId = (Integer) parameter.get(Constants.build);
-        String[] tagNames = getTags(buildId);
-        Map[] result = new Map[tagNames.length];
-        for (int i = 0; i < tagNames.length; i++) {
-            String tagName = tagNames[i];
-            Map map = new HashMap(1);
-            map.put(Constants.name, tagName);
-            result[i] = map;
 
-        }
-        return result;
-    }
-
-    private String[] getTags(Integer buildId) {
-        for (int i = 0; i < builds.size(); i++) {
-            FakeBuild get = builds.get(i);
-            if (get.getBuildID() == buildId) {
-                try {
-                    return get.guessTags();
-                } catch (ProjectMappingExceptions.ProjectMappingException e) {
-                    return new String[0];
-                }
+    public Set<String> getTags(Integer buildId) {
+        for (FakeBuild build : builds) {
+            if (build.getBuildID() == buildId) {
+                return build.getTags();
             }
         }
-        return new String[0];
+        return Collections.emptySet();
     }
-
+/*
     void checkAll() {
         for (String project : projects) {
             check(project);
@@ -271,34 +209,19 @@ public class FakeKojiDB {
             }
         }
     }
+*/
 
-    Object[] getRpms(Object get, Object get0) {
-        return getRpmsI((Integer) get, (Object[]) get0);
-    }
-
-    /**
-     *
-     * @param buildDd
-     * @param archs String[]
-     * @return array of hashmaps
-     */
-    Object[] getRpmsI(Integer buildDd, Object[] archs) {
-        FakeBuild build = getBuildById(buildDd);
+    List<RPM> getRpms(Integer buildId, List<String> archs) {
+        FakeBuild build = getBuildById(buildId);
         if (build == null) {
-            return new Object[0];
+            return Collections.emptyList();
         }
-        return build.getRpmsAsArrayOfMaps(archs);
+        return build.getRpms(archs);
     }
 
-    Object[] getArchives(Object get, Object get0) {
-        return getArchivesI((Integer) get, (Object[]) get0);
-    }
 
-    /**
-     * same as rpms but on windows (solaris?) archives
-     */
-    Object[] getArchivesI(Integer buildDd, Object[] archs) {
-        return new Object[0];
+    // all files other than rpms(tarxz, msi, ...) should be contained here
+    List<String> getArchives(Object get, Object get0) {
+        return Collections.emptyList();
     }
-
 }

--- a/koji-scm-lib/src/main/java/hudson/plugins/scm/koji/client/BuildMatcher.java
+++ b/koji-scm-lib/src/main/java/hudson/plugins/scm/koji/client/BuildMatcher.java
@@ -27,26 +27,25 @@ import hudson.plugins.scm.koji.Constants;
 import hudson.plugins.scm.koji.client.tools.XmlRpcHelper;
 import hudson.plugins.scm.koji.model.Build;
 import hudson.plugins.scm.koji.model.RPM;
+import org.fakekoji.xmlrpc.server.XmlRpcRequestParams;
+import org.fakekoji.xmlrpc.server.XmlRpcRequestParamsBuilder;
+import org.fakekoji.xmlrpc.server.XmlRpcResponse;
+
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class BuildMatcher {
 
-    public static enum OredBy {
-
+    public enum OrderBy {
         DATE, VERSION
     }
 
@@ -56,7 +55,7 @@ public class BuildMatcher {
     private final int maxBuilds;
     private final String pkgName;
     private final String arch;
-    private static final OredBy orderBy = OredBy.DATE;
+    private static final OrderBy orderBy = OrderBy.DATE;
 
     public BuildMatcher(String currentURL, Predicate<String> notProcessedNvrPredicate, GlobPredicate tagPredicate, int maxBuilds, String pkgName, String arch) {
         this.currentURL = currentURL;
@@ -68,128 +67,107 @@ public class BuildMatcher {
     }
 
     public Optional<Build> getResult() {
-        Stream<Build> results = listMatchingBuilds();
-
-        Optional<Build> buildOpt = results
-                .filter(b -> notProcessedNvrPredicate.test(b.getNvr()))
+       return listMatchingBuilds().stream()
+                .filter(build -> notProcessedNvrPredicate.test(build.getNvr()))
                 .findFirst();
-        return buildOpt;
     }
 
-    public Object[] getAll() {
-        Stream<Build> results = listMatchingBuilds();
-
-        Object[] buildOpt = results
-                .filter(b -> notProcessedNvrPredicate.test(b.getNvr()))
-                .toArray();
-        return buildOpt;
+    public Build[] getAll() {
+        return listMatchingBuilds().stream()
+                .filter(build -> notProcessedNvrPredicate.test(build.getNvr()))
+                .toArray(Build[]::new);
     }
 
-    private Stream<Build> listMatchingBuilds() {
-        List<Object> builds = Arrays.stream(pkgName.split(" "))
-                .map(this::listPackageBuilds)
-                .flatMap(Collection::stream)
-                .collect(Collectors.toList());
-
-        if (builds == null || builds.isEmpty()) {
-            return Stream.empty();
-        }
-        // ok, obvious over-engineering here:
-        return builds
-                .stream()
-                .sequential()
-                // sorting first, to go with relevant results first:
-                .sorted(this::compare)
-                // getting tags per build and filtering by tags right away:
-                .map(this::retrieveTags)
-                .filter(this::filterByTags)
-                // getting rpms and filtering by arch right away:
-                .map(this::retrieveRPMs)
-                .map(this::retrieveArchives)
-                .filter(this::filterByArch)
-                // do not go too far away into the past:
-                .limit(maxBuilds)
-                // composing final stream of builds:
-                .map(this::toBuild)
-                // sorting in reverse order:
-                .sorted(Comparator.reverseOrder());
+    private List<Build> listMatchingBuilds() {
+    	final List<Build> builds = new ArrayList<>();
+    	for (String packageName : pkgName.split(" ")) {
+    		builds.addAll(listPackageBuilds(packageName));
+		}
+		builds.sort(this::compare);
+		final List<Build> wantedBuilds = new ArrayList<>();
+    	for (Build build : builds) {
+    		final Set<String> tags = retrieveTags(build.getId());
+    		if (matchesTagPredicate(tags)) {
+				final List<RPM> rpms = new ArrayList<>();
+				rpms.addAll(retrieveRPMs(build.getId()));
+				rpms.addAll(retrieveArchives(build));
+				if (!rpms.isEmpty()) {
+					wantedBuilds.add(new Build(
+							build.getId(),
+							build.getName(),
+							build.getVersion(),
+							build.getRelease(),
+							build.getNvr(),
+							build.getCompletionTime(),
+							rpms,
+							tags,
+							null
+					));
+				}
+				if (wantedBuilds.size() >= maxBuilds) {
+					break;
+				}
+			}
+		}
+    	wantedBuilds.sort(Comparator.reverseOrder());
+		return wantedBuilds;
     }
 
-    private List<Object> listPackageBuilds(String packageName) {
-        Integer packageId = (Integer) execute(Constants.getPackageID, packageName);
+    private Integer getPackageId(String packageName) {
+        final XmlRpcRequestParamsBuilder paramsBuilder = new XmlRpcRequestParamsBuilder();
+        paramsBuilder.setPackageName(packageName);
+        final XmlRpcRequestParams params = paramsBuilder.build();
+        final XmlRpcResponse response = execute(Constants.getPackageID, params);
+        return response.getPackageId();
+    }
+
+    private List<Build> listPackageBuilds(String packageName) {
+        Integer packageId = getPackageId(packageName);
         if (packageId == null) {
             return Collections.emptyList();
         }
+        final XmlRpcRequestParamsBuilder paramsBuilder = new XmlRpcRequestParamsBuilder();
+        paramsBuilder.setPackageId(packageId);
+        paramsBuilder.setStarstar(Boolean.TRUE);
+        paramsBuilder.setState(1);
+        final XmlRpcRequestParams params = paramsBuilder.build();
 
-        Map paramsMap = new HashMap();
-        paramsMap.put(Constants.packageID, packageId);
-        paramsMap.put("state", 1);
-        paramsMap.put("__starstar", Boolean.TRUE);
-
-        Object[] results = (Object[]) execute(Constants.listBuilds, paramsMap);
-        if (results == null || results.length < 1) {
+        final XmlRpcResponse response = execute(Constants.listBuilds, params);
+        List<Build> builds = response.getBuilds();
+        if (builds == null || builds.isEmpty()) {
             return Collections.emptyList();
         }
-        return Arrays.asList(results);
+        return builds;
     }
 
-    private Object retrieveTags(Object o) {
-        if (!(o instanceof Map)) {
-            throw new RuntimeException("Map instance expected, got: " + o);
-        }
+    private Set<String> retrieveTags(Integer buildId) {
+        final XmlRpcRequestParamsBuilder paramsBuilder = new XmlRpcRequestParamsBuilder();
+        paramsBuilder.setBuildId(buildId);
+        paramsBuilder.setStarstar(Boolean.TRUE);
+        final XmlRpcRequestParams params = paramsBuilder.build();
 
-        Map m = (Map) o;
-        //Object buildName = m.get(nvr);
-
-        Map paramsMap = new HashMap();
-        paramsMap.put(Constants.build, m.get(Constants.build_id));
-        paramsMap.put("__starstar", Boolean.TRUE);
-
-        Object res = execute(Constants.listTags, paramsMap);
-        if (res != null && (res instanceof Object[]) && ((Object[]) res).length > 0) {
-            m.put("tags", res);
-        }
-        return o;
+        final XmlRpcResponse response = execute(Constants.listTags, params);
+        return response.getTags();
     }
 
-    private boolean filterByTags(Object o) {
-        if (!(o instanceof Map)) {
-            throw new RuntimeException("Map instance expected, got: " + o);
-        }
-        Map m = (Map) o;
-        Object[] tags = (Object[]) m.get("tags");
-        if (tags == null) {
-            return false;
-        }
-        boolean tagMatch = Arrays
-                .stream(tags)
-                .map(t -> ((Map<String, String>) t).get(Constants.name))
+    private boolean matchesTagPredicate(Set<String> tags) {
+        return tags
+				.stream()
                 .anyMatch(tagPredicate);
-        return tagMatch;
     }
 
-    private Object retrieveRPMs(Object o) {
-        if (!(o instanceof Map)) {
-            throw new RuntimeException("Map instance expected, got: " + o);
-        }
-        Map m = (Map) o;
-
-        Map paramsMap = new HashMap();
-        paramsMap.put(Constants.buildID, m.get(Constants.build_id));
-        String[] arches = composeArchesArray();
+    private List<RPM> retrieveRPMs(Integer buildId) {
+        final XmlRpcRequestParamsBuilder paramsBuilder = new XmlRpcRequestParamsBuilder();
+        paramsBuilder.setBuildId(buildId);
+        paramsBuilder.setStarstar(Boolean.TRUE);
+        final String[] arches = composeArchesArray();
         if (arches != null) {
-            paramsMap.put(Constants.arches, arches);
+            paramsBuilder.setArchs(Arrays.asList(arches));
         }
-        paramsMap.put("__starstar", Boolean.TRUE);
-
-        Object res = execute(Constants.listRPMs, paramsMap);
-        if (res != null && (res instanceof Object[]) && ((Object[]) res).length > 0) {
-            //the map already have tag rpms, but for ALL architectures. Replacing.
-            //also this is called BEFORE retrieveArchives so we can put instead of add
-            m.put(Constants.rpms, res);
-        }
-
-        return o;
+        final XmlRpcRequestParams params = paramsBuilder.build();
+        final XmlRpcResponse response = execute(Constants.listRPMs, params);
+        final List<RPM> rpms = response.getRpms();
+        return rpms == null ? Collections.emptyList() : rpms;
     }
 
     /**
@@ -200,136 +178,54 @@ public class BuildMatcher {
      * later used to compose filepath. Unlike with RPMs, filename is received
      * here so we can store it.
      */
-    private Object retrieveArchives(Object o) {
-        if (!(o instanceof Map)) {
-            throw new RuntimeException("Map instance expected, got: " + o);
-        }
-        Map m = (Map) o;
+    private List<RPM> retrieveArchives(Build build) {
+        final XmlRpcRequestParamsBuilder paramsBuilder = new XmlRpcRequestParamsBuilder();
+        paramsBuilder.setBuildId(build.getId());
 
-        Map<String, Object> paramsMap = new HashMap<>();
-        paramsMap.put(Constants.buildID, m.get(Constants.build_id));
-        String[] desiredArches = composeArchesArray();
-        List<String> supportedArches = new ArrayList<>(1);
+        final String[] desiredArches = composeArchesArray();
+        final List<String> supportedArches = new ArrayList<>(1);
         supportedArches.add("win");
-        paramsMap.put("__starstar", Boolean.TRUE);
-
-        Object listedArchives = execute(Constants.listArchives, paramsMap);
-        List<Object> filteredArchives = new ArrayList<>();
-        if (listedArchives != null && (listedArchives instanceof Object[])) {
-            for (Object archive : (Object[]) listedArchives) {
-                if (archive != null && archive instanceof Map) {
-                    for (String arch : desiredArches) {
-                        Map<String, Object> rpms = new HashMap<>();
-                        rpms.putAll((Map<String, Object>) archive);
-                        rpms.put(Constants.name, m.get(Constants.name));
-                        rpms.put(Constants.version, m.get(Constants.version));
-                        rpms.put(Constants.release, m.get(Constants.release));
-                        rpms.put(Constants.arch, arch);
-                        rpms.put(Constants.nvr, ((Map) archive).get(Constants.filename));
-                        rpms.put(Constants.filename, ((Map) archive).get(Constants.filename));
-                        if (supportedArches.contains(arch)) {
-                            filteredArchives.add(rpms);
-                        }
-                    }
-                }
-            }
-
-            addRpmsToMap(m, filteredArchives.toArray());
-        }
-
-        return o;
+        paramsBuilder.setStarstar(Boolean.TRUE);
+        final XmlRpcRequestParams params = paramsBuilder.build();
+        final XmlRpcResponse response = execute(Constants.listArchives, params);
+        final List<String> archivefilenames = response.getArchives();
+        if (archivefilenames == null || archivefilenames.isEmpty()) {
+        	return Collections.emptyList();
+		}
+        final List<RPM> archives = new ArrayList<>(archivefilenames.size());
+        for (String archiveName : archivefilenames) {
+			for (String arch : desiredArches) {
+				if (supportedArches.contains(arch)) {
+					archives.add(new RPM(
+							build.getName(),
+							build.getVersion(),
+							build.getRelease(),
+							archiveName,
+							arch,
+							archiveName
+					));
+				}
+			}
+		}
+        return archives;
     }
 
-    private void addRpmsToMap(Map m, Object[] listedArchivesArray) {
-        addToMap(Constants.rpms, m, listedArchivesArray);
-    }
-
-    private void addToMap(String key, Map m, Object[] listedArchivesArray) {
-        Object orig = m.put(key, listedArchivesArray);
-        if (orig != null && orig instanceof Object[]) {
-            Object[] listedOrigianlArray = (Object[]) orig;
-            Object[] connectedArrays = new Object[listedOrigianlArray.length + listedArchivesArray.length];
-            System.arraycopy(listedOrigianlArray, 0, connectedArrays, 0, listedOrigianlArray.length);
-            System.arraycopy(listedArchivesArray, 0, connectedArrays, listedOrigianlArray.length, listedArchivesArray.length);
-            m.put(key, connectedArrays);
-        }
-    }
-
-    private boolean filterByArch(Object o) {
-        if (!(o instanceof Map)) {
-            throw new RuntimeException("Map instance expected, got: " + o);
-        }
-        /*        ??        */
-//        if (arch == null || arch.isEmpty()) {
-//            throw new RuntimeException("Arch cannot be empty");
-//        }
-        Map m = (Map) o;
-        boolean hasRpms = m.get(Constants.rpms) != null;
-        return hasRpms;
-    }
-
-    private Build toBuild(Object o) {
-        if (!(o instanceof Map)) {
-            throw new RuntimeException("Map instance expected, got: " + o);
-        }
-
-        Map<String, String> m = (Map) o;
-        return new Build((Integer) ((Map) o).get(Constants.build_id),
-                m.get(Constants.name),
-                m.get(Constants.version),
-                m.get(Constants.release),
-                m.get(Constants.nvr),
-                dateKojiToIso(m.get(Constants.completion_time)),
-                Arrays
-                .stream((Object[]) ((Map) o).get(Constants.rpms))
-                .map(this::toRPM)
-                .collect(Collectors.toList()),
-                Arrays
-                .stream((Object[]) ((Map) o).get("tags"))
-                .map(t -> ((Map<String, String>) t).get(Constants.name))
-                .collect(Collectors.toSet()), null
-        );
-    }
-
-    private RPM toRPM(Object o) {
-        if (!(o instanceof Map)) {
-            throw new RuntimeException("Map instance expected, got: " + o);
-        }
-        Map<String, String> m = (Map) o;
-        return new RPM(
-                m.get(Constants.name),
-                m.get(Constants.version),
-                m.get(Constants.release),
-                m.get(Constants.nvr),
-                m.get(Constants.arch),
-                m.get(Constants.filename));
-    }
-
-    private String dateKojiToIso(String kojiDate) {
-        LocalDateTime date = LocalDateTime.parse(kojiDate, Constants.DTF);
-        return DateTimeFormatter.ISO_DATE_TIME.format(date);
-    }
-
-    private int compare(Object o1, Object o2) {
+    private int compare(Build b1, Build b2) {
         switch (orderBy) {
             case DATE:
-                return compareBuildsByCompletionTime(o1, o2);
+                return compareBuildsByCompletionTime(b1, b2);
             case VERSION:
-                return compareBuildVersions(o1, o2);
+                return compareBuildVersions(b1, b2);
         }
         throw new RuntimeException("Unknown order");
-    }
-
-    private String[] composePkgsArray() {
-        return composeArray(pkgName);
     }
 
     private String[] composeArchesArray() {
         return composeArray(arch);
     }
 
-    protected Object execute(String methodName, Object... args) {
-        return new XmlRpcHelper.XmlRpcExecutioner(currentURL).execute(methodName, args);
+    protected XmlRpcResponse execute(String methodName, XmlRpcRequestParams params) {
+        return new XmlRpcHelper.XmlRpcExecutioner(currentURL).execute(methodName, params);
     }
 
     private static String[] composeArray(String values) {
@@ -348,79 +244,30 @@ public class BuildMatcher {
         return list.toArray(new String[list.size()]);
     }
 
-    public static int compareBuildsByCompletionTime(Object o1, Object o2) {
-        if (o1 == null) {
-            if (o2 == null) {
-                return 0;
-            }
-            // o2 is not null:
-            return 1;
-        }
-        // o1 is not null:
-        if (o2 == null) {
-            return -1;
-        }
-        // both o1 and o2 are not null:
-        if (!(o1 instanceof Map) || !(o2 instanceof Map)) {
-            throw new RuntimeException("Expected Map instances, got: " + o1 + " and " + o2);
-        }
-        Map<String, Object> m1 = (Map) o1;
-        Map<String, Object> m2 = (Map) o2;
-        return comapreKojiTime((String) m1.get("completion_time"), (String) m2.get("completion_time"), Constants.DTF);
+    public static int compareBuildsByCompletionTime(Build b1, Build b2) {
+        return compareKojiTime(b1.getCompletionTime(), b2.getCompletionTime(), Constants.DTF);
 
     }
 
-    public static int compareBuildsByCompletionTime(Build o1, Build o2) {
-        return comapreKojiTime(o1.getCompletionTime(), o2.getCompletionTime(), Constants.DTF2);
-    }
-    public static int comapreKojiTime(String s1, String s2, DateTimeFormatter d) {
+    public static int compareKojiTime(String s1, String s2, DateTimeFormatter d) {
         LocalDateTime thisCompletionTime = LocalDateTime.parse(s1, d);
         LocalDateTime thatCompletionTime = LocalDateTime.parse(s2, d);
         return thatCompletionTime.compareTo(thisCompletionTime);
     }
 
-    public static int compareBuildVersions(Object o1, Object o2) {
-        if (o1 == null) {
-            if (o2 == null) {
-                return 0;
-            }
-            // o2 is not null:
-            return 1;
-        }
-        // o1 is not null:
-        if (o2 == null) {
-            return -1;
-        }
-        // both o1 and o2 are not null:
-        if (!(o1 instanceof Map) || !(o2 instanceof Map)) {
-            throw new RuntimeException("Expected Map instances, got: " + o1 + " and " + o2);
-        }
-        Map<String, String> m1 = (Map) o1;
-        Map<String, String> m2 = (Map) o2;
-
+    public static int compareBuildVersions(Build b1, Build b2) {
         // comparing versions:
-        int res = compareStrings(m1.get(Constants.version), m2.get(Constants.version));
+        int res = compareStrings(b1.getVersion(), b2.getVersion());
         if (res != 0) {
             return res;
         }
         // version are identical, comparing releases:
-        return compareStrings(m1.get(Constants.release), m2.get(Constants.release));
+        return compareStrings(b1.getRelease(), b2.getRelease());
     }
 
-    public static int compareStrings(String o1, String o2) {
-        if (o1 == null) {
-            if (o2 == null) {
-                return 0;
-            }
-            return 1;
-        }
-        // if we are here - o1 is not null:
-        if (o2 == null) {
-            return -1;
-        }
-        // if we are here - none of the arguments is null:
-        StringTokenizer tokenizer1 = new StringTokenizer(o1, "-.");
-        StringTokenizer tokenizer2 = new StringTokenizer(o2, "-.");
+    public static int compareStrings(String s1, String s2) {
+        StringTokenizer tokenizer1 = new StringTokenizer(s1, "-.");
+        StringTokenizer tokenizer2 = new StringTokenizer(s2, "-.");
         while (tokenizer1.hasMoreTokens() && tokenizer2.hasMoreTokens()) {
             String t1 = tokenizer1.nextToken();
             String t2 = tokenizer2.nextToken();

--- a/koji-scm-lib/src/main/java/hudson/plugins/scm/koji/client/BuildMatcher.java
+++ b/koji-scm-lib/src/main/java/hudson/plugins/scm/koji/client/BuildMatcher.java
@@ -126,12 +126,11 @@ public class BuildMatcher {
         if (packageId == null) {
             return Collections.emptyList();
         }
-        final XmlRpcRequestParamsBuilder paramsBuilder = new XmlRpcRequestParamsBuilder();
-        paramsBuilder.setPackageId(packageId);
-        paramsBuilder.setStarstar(Boolean.TRUE);
-        paramsBuilder.setState(1);
-        final XmlRpcRequestParams params = paramsBuilder.build();
-
+        final XmlRpcRequestParams params = new XmlRpcRequestParamsBuilder()
+                .setPackageId(packageId)
+                .setStarstar(Boolean.TRUE)
+                .setState(1)
+                .build();
         final XmlRpcResponse response = execute(Constants.listBuilds, params);
         List<Build> builds = response.getBuilds();
         if (builds == null || builds.isEmpty()) {
@@ -141,10 +140,10 @@ public class BuildMatcher {
     }
 
     private Set<String> retrieveTags(Integer buildId) {
-        final XmlRpcRequestParamsBuilder paramsBuilder = new XmlRpcRequestParamsBuilder();
-        paramsBuilder.setBuildId(buildId);
-        paramsBuilder.setStarstar(Boolean.TRUE);
-        final XmlRpcRequestParams params = paramsBuilder.build();
+        final XmlRpcRequestParams params = new XmlRpcRequestParamsBuilder()
+                .setBuildId(buildId)
+                .setStarstar(Boolean.TRUE)
+                .build();
 
         final XmlRpcResponse response = execute(Constants.listTags, params);
         return response.getTags();
@@ -157,14 +156,11 @@ public class BuildMatcher {
     }
 
     private List<RPM> retrieveRPMs(Integer buildId) {
-        final XmlRpcRequestParamsBuilder paramsBuilder = new XmlRpcRequestParamsBuilder();
-        paramsBuilder.setBuildId(buildId);
-        paramsBuilder.setStarstar(Boolean.TRUE);
-        final String[] arches = composeArchesArray();
-        if (arches != null) {
-            paramsBuilder.setArchs(Arrays.asList(arches));
-        }
-        final XmlRpcRequestParams params = paramsBuilder.build();
+        final XmlRpcRequestParams params = new XmlRpcRequestParamsBuilder()
+                .setBuildId(buildId)
+                .setStarstar(Boolean.TRUE)
+                .setArchs(composeArchesList())
+                .build();
         final XmlRpcResponse response = execute(Constants.listRPMs, params);
         final List<RPM> rpms = response.getRpms();
         return rpms == null ? Collections.emptyList() : rpms;
@@ -179,14 +175,13 @@ public class BuildMatcher {
      * here so we can store it.
      */
     private List<RPM> retrieveArchives(Build build) {
-        final XmlRpcRequestParamsBuilder paramsBuilder = new XmlRpcRequestParamsBuilder();
-        paramsBuilder.setBuildId(build.getId());
-
-        final String[] desiredArches = composeArchesArray();
+        final List<String> desiredArches = composeArchesList();
         final List<String> supportedArches = new ArrayList<>(1);
         supportedArches.add("win");
-        paramsBuilder.setStarstar(Boolean.TRUE);
-        final XmlRpcRequestParams params = paramsBuilder.build();
+        final XmlRpcRequestParams params = new XmlRpcRequestParamsBuilder()
+                .setBuildId(build.getId())
+                .setStarstar(Boolean.TRUE)
+                .build();
         final XmlRpcResponse response = execute(Constants.listArchives, params);
         final List<String> archivefilenames = response.getArchives();
         if (archivefilenames == null || archivefilenames.isEmpty()) {
@@ -220,15 +215,15 @@ public class BuildMatcher {
         throw new RuntimeException("Unknown order");
     }
 
-    private String[] composeArchesArray() {
-        return composeArray(arch);
+    private List<String> composeArchesList() {
+        return composeList(arch);
     }
 
     protected XmlRpcResponse execute(String methodName, XmlRpcRequestParams params) {
         return new XmlRpcHelper.XmlRpcExecutioner(currentURL).execute(methodName, params);
     }
 
-    private static String[] composeArray(String values) {
+    private static List<String> composeList(String values) {
         if (values == null || values.trim().isEmpty()) {
             return null;
         }
@@ -241,7 +236,7 @@ public class BuildMatcher {
                 list.add(trimmed);
             }
         }
-        return list.toArray(new String[list.size()]);
+        return list;
     }
 
     public static int compareBuildsByCompletionTime(Build b1, Build b2) {

--- a/koji-scm-lib/src/main/java/hudson/plugins/scm/koji/model/Build.java
+++ b/koji-scm-lib/src/main/java/hudson/plugins/scm/koji/model/Build.java
@@ -120,8 +120,8 @@ public class Build implements Comparable<Build>, java.io.Serializable {
         if (this == build) {
             return 0;
         }
-		final String thisCompletionTime = DateTimeFormatter.ISO_DATE_TIME.format(LocalDateTime.parse(getCompletionTime(), Constants.DTF));
-		final String thatCompletionTime = DateTimeFormatter.ISO_DATE_TIME.format(LocalDateTime.parse(build.getCompletionTime(), Constants.DTF));
+        final String thisCompletionTime = DateTimeFormatter.ISO_DATE_TIME.format(LocalDateTime.parse(getCompletionTime(), Constants.DTF));
+        final String thatCompletionTime = DateTimeFormatter.ISO_DATE_TIME.format(LocalDateTime.parse(build.getCompletionTime(), Constants.DTF));
         final LocalDateTime thisCompletionDateTime = LocalDateTime.parse(thisCompletionTime, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
         final LocalDateTime thatCompletionDateTime = LocalDateTime.parse(thatCompletionTime, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
         return thatCompletionDateTime.compareTo(thisCompletionDateTime);

--- a/koji-scm-lib/src/main/java/hudson/plugins/scm/koji/model/Build.java
+++ b/koji-scm-lib/src/main/java/hudson/plugins/scm/koji/model/Build.java
@@ -1,7 +1,6 @@
 package hudson.plugins.scm.koji.model;
 
 import hudson.plugins.scm.koji.Constants;
-import jdk.nashorn.internal.parser.DateParser;
 
 import java.net.URL;
 import java.time.LocalDateTime;
@@ -11,7 +10,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.StringTokenizer;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
@@ -69,7 +67,7 @@ public class Build implements Comparable<Build>, java.io.Serializable {
         this.tags = null;
         this.manual = null;
     }
-    
+
     public boolean isManual(){
         if (manual == null){
             return false;
@@ -115,68 +113,18 @@ public class Build implements Comparable<Build>, java.io.Serializable {
     }
 
     @Override
-    public int compareTo(Build o) {
-        if (o == null) {
+    public int compareTo(Build build) {
+        if (build == null) {
             return -1;
         }
-        if (this == o) {
+        if (this == build) {
             return 0;
         }
-
-        LocalDateTime thisCompletionTime = LocalDateTime.parse(this.completionTime, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
-        LocalDateTime thatCompletionTime = LocalDateTime.parse(o.completionTime, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
-        return thatCompletionTime.compareTo(thisCompletionTime);
-    }
-
-    private int compare(String o1, String o2) {
-        if (o1 == null) {
-            if (o2 == null) {
-                return 0;
-            }
-            return 1;
-        }
-        // if we are here - o1 is not null:
-        if (o2 == null) {
-            return -1;
-        }
-        // if we are here - none of the arguments is null:
-        StringTokenizer tokenizer1 = new StringTokenizer(o1, "-.");
-        StringTokenizer tokenizer2 = new StringTokenizer(o2, "-.");
-        while (tokenizer1.hasMoreTokens() && tokenizer2.hasMoreTokens()) {
-            String t1 = tokenizer1.nextToken();
-            String t2 = tokenizer2.nextToken();
-            if (allDigits(t1) && allDigits(t2)) {
-                int i1 = Integer.parseInt(t1);
-                int i2 = Integer.parseInt(t2);
-                int intCompared = i1 - i2;
-                if (intCompared != 0) {
-                    return intCompared > 0 ? -1 : 1;
-                }
-                continue;
-            }
-            int stringCompared = t1.compareTo(t2);
-            if (stringCompared != 0) {
-                return stringCompared > 0 ? -1 : 1;
-            }
-        }
-        // if we are here then one of strings has ended,
-        // longer will be considered bigger version:
-        if (tokenizer1.hasMoreTokens()) {
-            return -1;
-        }
-        if (tokenizer2.hasMoreTokens()) {
-            return 1;
-        }
-        return 0;
-    }
-
-    private boolean allDigits(String str) {
-        for (int i = 0; i < str.length(); i++) {
-            if (!Character.isDigit(str.charAt(i))) {
-                return false;
-            }
-        }
-        return true;
+		final String thisCompletionTime = DateTimeFormatter.ISO_DATE_TIME.format(LocalDateTime.parse(getCompletionTime(), Constants.DTF));
+		final String thatCompletionTime = DateTimeFormatter.ISO_DATE_TIME.format(LocalDateTime.parse(build.getCompletionTime(), Constants.DTF));
+        final LocalDateTime thisCompletionDateTime = LocalDateTime.parse(thisCompletionTime, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+        final LocalDateTime thatCompletionDateTime = LocalDateTime.parse(thatCompletionTime, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+        return thatCompletionDateTime.compareTo(thisCompletionDateTime);
     }
 
     public String getDownloadUrl() {

--- a/koji-scm-lib/src/main/java/org/fakekoji/xmlrpc/server/XmlRpcRequestParams.java
+++ b/koji-scm-lib/src/main/java/org/fakekoji/xmlrpc/server/XmlRpcRequestParams.java
@@ -16,23 +16,23 @@ public class XmlRpcRequestParams implements Serializable {
     private final Integer state;
     private final List<String> archs;
 
-	public XmlRpcRequestParams(
-			String packageName,
-			Integer packageId,
-			Integer buildId,
-			Boolean starstar,
-			Integer state,
-			List<String> archs
-	) {
-		this.packageName = packageName;
-		this.packageId = packageId;
-		this.buildId = buildId;
-		this.starstar = starstar;
-		this.state = state;
-		this.archs = archs;
-	}
+    public XmlRpcRequestParams(
+            String packageName,
+            Integer packageId,
+            Integer buildId,
+            Boolean starstar,
+            Integer state,
+            List<String> archs
+    ) {
+        this.packageName = packageName;
+        this.packageId = packageId;
+        this.buildId = buildId;
+        this.starstar = starstar;
+        this.state = state;
+        this.archs = archs;
+    }
 
-	public String getPackageName() {
+    public String getPackageName() {
         return packageName;
     }
 
@@ -57,37 +57,37 @@ public class XmlRpcRequestParams implements Serializable {
     }
 
     public Object toObject(String methodName) {
-		if (methodName.equals(Constants.getPackageID)) {
-			return packageName;
-		}
-		return toMap(methodName);
-	}
+        if (methodName.equals(Constants.getPackageID)) {
+            return packageName;
+        }
+        return toMap(methodName);
+    }
 
     public Map<String, Object> toMap(String methodName) {
-		final Map<String, Object> map = new HashMap<>();
-		if (packageId != null) {
-			map.put(Constants.packageID, packageId);
-		}
-		if (buildId != null) {
-			switch (methodName) {
-				case Constants.listTags:
-					map.put(Constants.build, buildId);
-					break;
-				case Constants.listRPMs:
-				case Constants.listArchives:
-					map.put(Constants.buildID, buildId);
-					break;
-			}
-		}
-		if (archs != null && !archs.isEmpty()) {
-			map.put(Constants.arches, archs.toArray());
-		}
-		if (starstar != null) {
-			map.put("__starstar", starstar);
-		}
-		if (state != null) {
-			map.put("state", state);
-		}
-		return map;
-	}
+        final Map<String, Object> map = new HashMap<>();
+        if (packageId != null) {
+            map.put(Constants.packageID, packageId);
+        }
+        if (buildId != null) {
+            switch (methodName) {
+                case Constants.listTags:
+                    map.put(Constants.build, buildId);
+                    break;
+                case Constants.listRPMs:
+                case Constants.listArchives:
+                    map.put(Constants.buildID, buildId);
+                    break;
+            }
+        }
+        if (archs != null && !archs.isEmpty()) {
+            map.put(Constants.arches, archs.toArray());
+        }
+        if (starstar != null) {
+            map.put("__starstar", starstar);
+        }
+        if (state != null) {
+            map.put("state", state);
+        }
+        return map;
+    }
 }

--- a/koji-scm-lib/src/main/java/org/fakekoji/xmlrpc/server/XmlRpcRequestParams.java
+++ b/koji-scm-lib/src/main/java/org/fakekoji/xmlrpc/server/XmlRpcRequestParams.java
@@ -1,0 +1,93 @@
+package org.fakekoji.xmlrpc.server;
+
+import hudson.plugins.scm.koji.Constants;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class XmlRpcRequestParams implements Serializable {
+
+    private final String packageName;
+    private final Integer packageId;
+    private final Integer buildId;
+    private final Boolean starstar;
+    private final Integer state;
+    private final List<String> archs;
+
+	public XmlRpcRequestParams(
+			String packageName,
+			Integer packageId,
+			Integer buildId,
+			Boolean starstar,
+			Integer state,
+			List<String> archs
+	) {
+		this.packageName = packageName;
+		this.packageId = packageId;
+		this.buildId = buildId;
+		this.starstar = starstar;
+		this.state = state;
+		this.archs = archs;
+	}
+
+	public String getPackageName() {
+        return packageName;
+    }
+
+    public Integer getPackageId() {
+        return packageId;
+    }
+
+    public Integer getBuildId() {
+        return buildId;
+    }
+
+    public Boolean getStarstar() {
+        return starstar;
+    }
+
+    public Integer getState() {
+        return state;
+    }
+
+    public List<String> getArchs() {
+        return archs;
+    }
+
+    public Object toObject(String methodName) {
+		if (methodName.equals(Constants.getPackageID)) {
+			return packageName;
+		}
+		return toMap(methodName);
+	}
+
+    public Map<String, Object> toMap(String methodName) {
+		final Map<String, Object> map = new HashMap<>();
+		if (packageId != null) {
+			map.put(Constants.packageID, packageId);
+		}
+		if (buildId != null) {
+			switch (methodName) {
+				case Constants.listTags:
+					map.put(Constants.build, buildId);
+					break;
+				case Constants.listRPMs:
+				case Constants.listArchives:
+					map.put(Constants.buildID, buildId);
+					break;
+			}
+		}
+		if (archs != null && !archs.isEmpty()) {
+			map.put(Constants.arches, archs.toArray());
+		}
+		if (starstar != null) {
+			map.put("__starstar", starstar);
+		}
+		if (state != null) {
+			map.put("state", state);
+		}
+		return map;
+	}
+}

--- a/koji-scm-lib/src/main/java/org/fakekoji/xmlrpc/server/XmlRpcRequestParamsBuilder.java
+++ b/koji-scm-lib/src/main/java/org/fakekoji/xmlrpc/server/XmlRpcRequestParamsBuilder.java
@@ -24,28 +24,34 @@ public class XmlRpcRequestParamsBuilder {
         this.archs = null;
     }
 
-    public void setPackageName(String packageName) {
+    public XmlRpcRequestParamsBuilder setPackageName(String packageName) {
         this.packageName = packageName;
+        return this;
     }
 
-    public void setPackageId(Integer packageId) {
+    public XmlRpcRequestParamsBuilder setPackageId(Integer packageId) {
         this.packageId = packageId;
+        return this;
     }
 
-    public void setBuildId(Integer buildId) {
+    public XmlRpcRequestParamsBuilder setBuildId(Integer buildId) {
         this.buildId = buildId;
+        return this;
     }
 
-    public void setStarstar(Boolean starstar) {
+    public XmlRpcRequestParamsBuilder setStarstar(Boolean starstar) {
         this.starstar = starstar;
+        return this;
     }
 
-    public void setState(Integer state) {
+    public XmlRpcRequestParamsBuilder setState(Integer state) {
         this.state = state;
+        return this;
     }
 
-    public void setArchs(List<String> archs) {
+    public XmlRpcRequestParamsBuilder setArchs(List<String> archs) {
         this.archs = archs;
+        return this;
     }
 
     public XmlRpcRequestParams build() {
@@ -61,8 +67,7 @@ public class XmlRpcRequestParamsBuilder {
 
     public XmlRpcRequestParams build(Object object, String methodName) {
         if (object instanceof String) {
-            setPackageName((String) object);
-            return build();
+            return setPackageName((String) object).build();
         }
         return build((Map<String, Object>) object, methodName);
     }

--- a/koji-scm-lib/src/main/java/org/fakekoji/xmlrpc/server/XmlRpcRequestParamsBuilder.java
+++ b/koji-scm-lib/src/main/java/org/fakekoji/xmlrpc/server/XmlRpcRequestParamsBuilder.java
@@ -8,93 +8,93 @@ import java.util.Map;
 
 public class XmlRpcRequestParamsBuilder {
 
-	private String packageName;
-	private Integer packageId;
-	private Integer buildId;
-	private Boolean starstar;
-	private Integer state;
-	private List<String> archs;
+    private String packageName;
+    private Integer packageId;
+    private Integer buildId;
+    private Boolean starstar;
+    private Integer state;
+    private List<String> archs;
 
-	public XmlRpcRequestParamsBuilder() {
-		this.packageName = null;
-		this.packageId = null;
-		this.buildId = null;
-		this.starstar = null;
-		this.state = null;
-		this.archs = null;
-	}
+    public XmlRpcRequestParamsBuilder() {
+        this.packageName = null;
+        this.packageId = null;
+        this.buildId = null;
+        this.starstar = null;
+        this.state = null;
+        this.archs = null;
+    }
 
-	public void setPackageName(String packageName) {
-		this.packageName = packageName;
-	}
+    public void setPackageName(String packageName) {
+        this.packageName = packageName;
+    }
 
-	public void setPackageId(Integer packageId) {
-		this.packageId = packageId;
-	}
+    public void setPackageId(Integer packageId) {
+        this.packageId = packageId;
+    }
 
-	public void setBuildId(Integer buildId) {
-		this.buildId = buildId;
-	}
+    public void setBuildId(Integer buildId) {
+        this.buildId = buildId;
+    }
 
-	public void setStarstar(Boolean starstar) {
-		this.starstar = starstar;
-	}
+    public void setStarstar(Boolean starstar) {
+        this.starstar = starstar;
+    }
 
-	public void setState(Integer state) {
-		this.state = state;
-	}
+    public void setState(Integer state) {
+        this.state = state;
+    }
 
-	public void setArchs(List<String> archs) {
-		this.archs = archs;
-	}
+    public void setArchs(List<String> archs) {
+        this.archs = archs;
+    }
 
-	public XmlRpcRequestParams build() {
-		return new XmlRpcRequestParams(
-				packageName,
-				packageId,
-				buildId,
-				starstar,
-				state,
-				archs
-		);
-	}
+    public XmlRpcRequestParams build() {
+        return new XmlRpcRequestParams(
+                packageName,
+                packageId,
+                buildId,
+                starstar,
+                state,
+                archs
+        );
+    }
 
-	public XmlRpcRequestParams build(Object object, String methodName) {
-		if (object instanceof String) {
-			setPackageName((String) object);
-			return build();
-		}
-		return build((Map<String, Object>) object, methodName);
-	}
+    public XmlRpcRequestParams build(Object object, String methodName) {
+        if (object instanceof String) {
+            setPackageName((String) object);
+            return build();
+        }
+        return build((Map<String, Object>) object, methodName);
+    }
 
-	public XmlRpcRequestParams build(Map<String, Object> map, String methodName) {
-		final Object[] archs = (Object[]) map.get(Constants.arches);
-		final List<String> archList = new ArrayList<>();
-		if (archs != null) {
-			for (final Object arch : archs) {
-				archList.add((String) arch);
-			}
-		}
-		return new XmlRpcRequestParams(
-				null,
-				(Integer) map.get(Constants.packageID),
-				retrieveBuildId(map, methodName),
-				(Boolean) map.get("__starstar"),
-				(Integer) map.get("state"),
-				archList
-		);
-	}
+    public XmlRpcRequestParams build(Map<String, Object> map, String methodName) {
+        final Object[] archs = (Object[]) map.get(Constants.arches);
+        final List<String> archList = new ArrayList<>();
+        if (archs != null) {
+            for (final Object arch : archs) {
+                archList.add((String) arch);
+            }
+        }
+        return new XmlRpcRequestParams(
+                null,
+                (Integer) map.get(Constants.packageID),
+                retrieveBuildId(map, methodName),
+                (Boolean) map.get("__starstar"),
+                (Integer) map.get("state"),
+                archList
+        );
+    }
 
-	private Integer retrieveBuildId(Map<String, Object> map, String methodName) {
-		// listTags method requires 'build' as key and listRPMs and listArchives methods require buildID as key (sigh)
-		switch (methodName) {
-			case Constants.listTags:
-				return (Integer) map.get(Constants.build);
-			case Constants.listRPMs:
-			case Constants.listArchives:
-				return (Integer) map.get(Constants.buildID);
-			default:
-				return null;
-		}
-	}
+    private Integer retrieveBuildId(Map<String, Object> map, String methodName) {
+        // listTags method requires 'build' as key and listRPMs and listArchives methods require buildID as key (sigh)
+        switch (methodName) {
+            case Constants.listTags:
+                return (Integer) map.get(Constants.build);
+            case Constants.listRPMs:
+            case Constants.listArchives:
+                return (Integer) map.get(Constants.buildID);
+            default:
+                return null;
+        }
+    }
 }

--- a/koji-scm-lib/src/main/java/org/fakekoji/xmlrpc/server/XmlRpcRequestParamsBuilder.java
+++ b/koji-scm-lib/src/main/java/org/fakekoji/xmlrpc/server/XmlRpcRequestParamsBuilder.java
@@ -1,0 +1,100 @@
+package org.fakekoji.xmlrpc.server;
+
+import hudson.plugins.scm.koji.Constants;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class XmlRpcRequestParamsBuilder {
+
+	private String packageName;
+	private Integer packageId;
+	private Integer buildId;
+	private Boolean starstar;
+	private Integer state;
+	private List<String> archs;
+
+	public XmlRpcRequestParamsBuilder() {
+		this.packageName = null;
+		this.packageId = null;
+		this.buildId = null;
+		this.starstar = null;
+		this.state = null;
+		this.archs = null;
+	}
+
+	public void setPackageName(String packageName) {
+		this.packageName = packageName;
+	}
+
+	public void setPackageId(Integer packageId) {
+		this.packageId = packageId;
+	}
+
+	public void setBuildId(Integer buildId) {
+		this.buildId = buildId;
+	}
+
+	public void setStarstar(Boolean starstar) {
+		this.starstar = starstar;
+	}
+
+	public void setState(Integer state) {
+		this.state = state;
+	}
+
+	public void setArchs(List<String> archs) {
+		this.archs = archs;
+	}
+
+	public XmlRpcRequestParams build() {
+		return new XmlRpcRequestParams(
+				packageName,
+				packageId,
+				buildId,
+				starstar,
+				state,
+				archs
+		);
+	}
+
+	public XmlRpcRequestParams build(Object object, String methodName) {
+		if (object instanceof String) {
+			setPackageName((String) object);
+			return build();
+		}
+		return build((Map<String, Object>) object, methodName);
+	}
+
+	public XmlRpcRequestParams build(Map<String, Object> map, String methodName) {
+		final Object[] archs = (Object[]) map.get(Constants.arches);
+		final List<String> archList = new ArrayList<>();
+		if (archs != null) {
+			for (final Object arch : archs) {
+				archList.add((String) arch);
+			}
+		}
+		return new XmlRpcRequestParams(
+				null,
+				(Integer) map.get(Constants.packageID),
+				retrieveBuildId(map, methodName),
+				(Boolean) map.get("__starstar"),
+				(Integer) map.get("state"),
+				archList
+		);
+	}
+
+	private Integer retrieveBuildId(Map<String, Object> map, String methodName) {
+		// listTags method requires 'build' as key and listRPMs and listArchives methods require buildID as key (sigh)
+		switch (methodName) {
+			case Constants.listTags:
+				return (Integer) map.get(Constants.build);
+			case Constants.listRPMs:
+			case Constants.listArchives:
+				return (Integer) map.get(Constants.buildID);
+			default:
+				return null;
+		}
+	}
+}

--- a/koji-scm-lib/src/main/java/org/fakekoji/xmlrpc/server/XmlRpcResponse.java
+++ b/koji-scm-lib/src/main/java/org/fakekoji/xmlrpc/server/XmlRpcResponse.java
@@ -1,0 +1,120 @@
+package org.fakekoji.xmlrpc.server;
+
+import hudson.plugins.scm.koji.Constants;
+import hudson.plugins.scm.koji.model.Build;
+import hudson.plugins.scm.koji.model.RPM;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class XmlRpcResponse implements Serializable {
+
+    private final List<Build> builds;
+    private final List<RPM> rpms;
+    private final Set<String> tags;
+    private final Integer packageId;
+    private final List<String> archives;
+
+    public XmlRpcResponse(
+            List<Build> builds,
+            List<RPM> rpms,
+            Set<String> tags,
+            Integer packageId,
+            List<String> archives
+    ) {
+        this.builds = builds;
+        this.rpms = rpms;
+        this.tags = tags;
+        this.packageId = packageId;
+        this.archives = archives;
+    }
+
+    public List<Build> getBuilds() {
+        return builds;
+    }
+
+    public List<RPM> getRpms() {
+        return rpms;
+    }
+
+    public Set<String> getTags() {
+        return tags;
+    }
+
+    public Integer getPackageId() {
+        return packageId;
+    }
+
+    public List<String> getArchives() {
+        return archives;
+    }
+
+    public Object toObject() {
+        if (builds != null) {
+            return buildsToListOfMaps(builds);
+        }
+        if (rpms != null) {
+            return rpmsToListOfMaps(rpms);
+        }
+        if (tags != null) {
+            return tagsToListOfMaps(tags);
+        }
+        if (packageId != null) {
+            return packageId;
+        }
+        return null;
+    }
+
+    private List<Map<String, Object>> rpmsToListOfMaps(List<RPM> rpms) {
+        List<Map<String, Object>> rpmMapsList = new ArrayList<>();
+        for (RPM rpm : rpms) {
+            rpmMapsList.add(rpmToMap(rpm));
+        }
+        return rpmMapsList;
+    }
+
+    private Map<String, Object> rpmToMap(RPM rpm) {
+        Map<String, Object> map = new HashMap<>();
+        map.put(Constants.release, rpm.getRelease());
+        map.put(Constants.version, rpm.getVersion());
+        map.put(Constants.name, rpm.getName());
+        map.put(Constants.filename, rpm.getFilename(""));
+        map.put(Constants.nvr, rpm.getNvr());
+        map.put(Constants.arch, rpm.getArch());
+        return map;
+    }
+
+    private List<Map<String, Object>> buildsToListOfMaps(List<Build> builds) {
+        List<Map<String, Object>> buildMapsList = new ArrayList<>();
+        for (Build build : builds) {
+            buildMapsList.add(buildToMap(build));
+        }
+        return buildMapsList;
+    }
+
+    private List<Map<String, Object>> tagsToListOfMaps(Set<String> tags) {
+        List<Map<String, Object>> mapList = new ArrayList<>();
+        for (String tag : tags) {
+            Map<String, Object> tagMap = new HashMap<>();
+            tagMap.put(Constants.name, tag);
+            mapList.add(tagMap);
+        }
+        return mapList;
+    }
+
+    private Map<String, Object> buildToMap(Build build) {
+        Map<String, Object> map = new HashMap<>();
+        map.put(Constants.name, build.getName());
+        map.put(Constants.version, build.getVersion());
+        map.put(Constants.release, build.getRelease());
+        map.put(Constants.nvr, build.getNvr());
+        map.put(Constants.build_id, build.getId());
+        map.put(Constants.completion_time, build.getCompletionTime());
+        map.put(Constants.rpms, rpmsToListOfMaps(build.getRpms()));
+        return map;
+    }
+}

--- a/koji-scm-lib/src/main/java/org/fakekoji/xmlrpc/server/XmlRpcResponseBuilder.java
+++ b/koji-scm-lib/src/main/java/org/fakekoji/xmlrpc/server/XmlRpcResponseBuilder.java
@@ -1,0 +1,171 @@
+package org.fakekoji.xmlrpc.server;
+
+import hudson.plugins.scm.koji.Constants;
+import hudson.plugins.scm.koji.model.Build;
+import hudson.plugins.scm.koji.model.RPM;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class XmlRpcResponseBuilder {
+
+	private List<Build> builds;
+	private List<RPM> rpms;
+	private Set<String> tags;
+	private Integer packageId;
+	private List<String> archives;
+
+	public XmlRpcResponseBuilder() {
+		builds = null;
+		rpms = null;
+		tags = null;
+		packageId = null;
+		archives = null;
+	}
+
+	public void setBuilds(List<Build> builds) {
+		this.builds = builds;
+	}
+
+	public void setRpms(List<RPM> rpms) {
+		this.rpms = rpms;
+	}
+
+	public void setTags(Set<String> tags) {
+		this.tags = tags;
+	}
+
+	public void setPackageId(Integer packageId) {
+		this.packageId = packageId;
+	}
+
+	public void setArchives(List<String> archives) {
+		this.archives = archives;
+	}
+
+	public XmlRpcResponse build() {
+		return new XmlRpcResponse(
+				builds,
+				rpms,
+				tags,
+				packageId,
+				archives
+		);
+	}
+
+	public XmlRpcResponse build(String methodName, Object object) {
+		if (methodName.equals(Constants.getPackageID) && object instanceof Integer) {
+			setPackageId((Integer) object);
+			return build();
+		}
+		if (object instanceof Object[]) {
+			final List<Object> list = Arrays.asList((Object[]) object);
+			switch (methodName) {
+				case Constants.listBuilds:
+					final List<Map<String, Object>> buildMaps = new ArrayList<>(list.size());
+					for (Object o : list) {
+						buildMaps.add((Map<String, Object>) o);
+					}
+					setBuilds(mapsToBuilds(buildMaps));
+					break;
+				case Constants.listRPMs:
+					final List<Map<String, Object>> rpmMaps = new ArrayList<>(list.size());
+					for (Object o : list) {
+						rpmMaps.add((Map<String, Object>) o);
+					}
+					setRpms(mapsToRpms(rpmMaps));
+					break;
+				case Constants.listArchives:
+					final List<Map<String, Object>> archiveMaps = new ArrayList<>(list.size());
+					for (Object o : list) {
+						archiveMaps.add((Map<String, Object>) o);
+					}
+					setArchives(mapsToArchives(archiveMaps));
+					break;
+				case Constants.listTags:
+					final Set<String> tags = new HashSet<>();
+					for (Object o : list) {
+						final Map tag = (Map) o;
+						tags.add((String) tag.get(Constants.name));
+					}
+					setTags(tags);
+					break;
+			}
+		}
+		return build();
+	}
+
+	public XmlRpcResponse build(Object object) {
+		if (object instanceof Integer) {
+			setPackageId((Integer) object);
+		}
+		return build();
+	}
+
+	private List<Build> mapsToBuilds(List<Map<String, Object>> maps) {
+		if (maps == null) {
+			return Collections.emptyList();
+		}
+		final List<Build> builds = new ArrayList<>(maps.size());
+		for (Map<String, Object> map : maps) {
+			builds.add(mapToBuild(map));
+		}
+		return builds;
+	}
+
+	private Build mapToBuild(Map<String, Object> map) {
+		return new Build(
+				(Integer) map.get(Constants.build_id),
+				(String) map.get(Constants.name),
+				(String) map.get(Constants.version),
+				(String) map.get(Constants.release),
+				(String) map.get(Constants.nvr),
+				(String) map.get(Constants.completion_time),
+				null,
+				null,
+				null
+		);
+	}
+
+	private List<RPM> mapsToRpms(List<Map<String, Object>> rpmMaps) {
+		if (rpmMaps == null) {
+			return Collections.emptyList();
+		}
+		final List<RPM> rpms = new ArrayList<>(rpmMaps.size());
+		for (Map<String, Object> map : rpmMaps) {
+			rpms.add(mapToRpm(map));
+		}
+		return rpms;
+	}
+
+	private List<String> mapsToArchives(List<Map<String, Object>> archiveMaps) {
+		if (archiveMaps == null) {
+			return Collections.emptyList();
+		}
+		final List<String> archives = new ArrayList<>(archiveMaps.size());
+		for (Map<String, Object> map : archiveMaps) {
+			archives.add(mapToArchive(map));
+		}
+		return archives;
+	}
+
+	private String mapToArchive(Map<String, Object> map) {
+		return (String) map.get(Constants.filename);
+	}
+
+	private RPM mapToRpm(Map<String, Object> map) {
+		return new RPM(
+				(String) map.get(Constants.name),
+				(String) map.get(Constants.version),
+				(String) map.get(Constants.release),
+				(String) map.get(Constants.nvr),
+				(String) map.get(Constants.arch),
+				(String) map.get(Constants.filename)
+		);
+	}
+}

--- a/koji-scm-lib/src/main/java/org/fakekoji/xmlrpc/server/XmlRpcResponseBuilder.java
+++ b/koji-scm-lib/src/main/java/org/fakekoji/xmlrpc/server/XmlRpcResponseBuilder.java
@@ -14,158 +14,152 @@ import java.util.Set;
 
 public class XmlRpcResponseBuilder {
 
-	private List<Build> builds;
-	private List<RPM> rpms;
-	private Set<String> tags;
-	private Integer packageId;
-	private List<String> archives;
+    private List<Build> builds;
+    private List<RPM> rpms;
+    private Set<String> tags;
+    private Integer packageId;
+    private List<String> archives;
 
-	public XmlRpcResponseBuilder() {
-		builds = null;
-		rpms = null;
-		tags = null;
-		packageId = null;
-		archives = null;
-	}
+    public XmlRpcResponseBuilder() {
+        builds = null;
+        rpms = null;
+        tags = null;
+        packageId = null;
+        archives = null;
+    }
 
-	public void setBuilds(List<Build> builds) {
-		this.builds = builds;
-	}
+    public void setBuilds(List<Build> builds) {
+        this.builds = builds;
+    }
 
-	public void setRpms(List<RPM> rpms) {
-		this.rpms = rpms;
-	}
+    public void setRpms(List<RPM> rpms) {
+        this.rpms = rpms;
+    }
 
-	public void setTags(Set<String> tags) {
-		this.tags = tags;
-	}
+    public void setTags(Set<String> tags) {
+        this.tags = tags;
+    }
 
-	public void setPackageId(Integer packageId) {
-		this.packageId = packageId;
-	}
+    public void setPackageId(Integer packageId) {
+        this.packageId = packageId;
+    }
 
-	public void setArchives(List<String> archives) {
-		this.archives = archives;
-	}
+    public void setArchives(List<String> archives) {
+        this.archives = archives;
+    }
 
-	public XmlRpcResponse build() {
-		return new XmlRpcResponse(
-				builds,
-				rpms,
-				tags,
-				packageId,
-				archives
-		);
-	}
+    public XmlRpcResponse build() {
+        return new XmlRpcResponse(builds, rpms, tags, packageId, archives);
+    }
 
-	public XmlRpcResponse build(String methodName, Object object) {
-		if (methodName.equals(Constants.getPackageID) && object instanceof Integer) {
-			setPackageId((Integer) object);
-			return build();
-		}
-		if (object instanceof Object[]) {
-			final List<Object> list = Arrays.asList((Object[]) object);
-			switch (methodName) {
-				case Constants.listBuilds:
-					final List<Map<String, Object>> buildMaps = new ArrayList<>(list.size());
-					for (Object o : list) {
-						buildMaps.add((Map<String, Object>) o);
-					}
-					setBuilds(mapsToBuilds(buildMaps));
-					break;
-				case Constants.listRPMs:
-					final List<Map<String, Object>> rpmMaps = new ArrayList<>(list.size());
-					for (Object o : list) {
-						rpmMaps.add((Map<String, Object>) o);
-					}
-					setRpms(mapsToRpms(rpmMaps));
-					break;
-				case Constants.listArchives:
-					final List<Map<String, Object>> archiveMaps = new ArrayList<>(list.size());
-					for (Object o : list) {
-						archiveMaps.add((Map<String, Object>) o);
-					}
-					setArchives(mapsToArchives(archiveMaps));
-					break;
-				case Constants.listTags:
-					final Set<String> tags = new HashSet<>();
-					for (Object o : list) {
-						final Map tag = (Map) o;
-						tags.add((String) tag.get(Constants.name));
-					}
-					setTags(tags);
-					break;
-			}
-		}
-		return build();
-	}
+    public XmlRpcResponse build(String methodName, Object object) {
+        if (methodName.equals(Constants.getPackageID) && object instanceof Integer) {
+            setPackageId((Integer) object);
+            return build();
+        }
+        if (object instanceof Object[]) {
+            final List<Object> list = Arrays.asList((Object[]) object);
+            switch (methodName) {
+                case Constants.listBuilds:
+                    final List<Map<String, Object>> buildMaps = new ArrayList<>(list.size());
+                    for (Object o : list) {
+                        buildMaps.add((Map<String, Object>) o);
+                    }
+                    setBuilds(mapsToBuilds(buildMaps));
+                    break;
+                case Constants.listRPMs:
+                    final List<Map<String, Object>> rpmMaps = new ArrayList<>(list.size());
+                    for (Object o : list) {
+                        rpmMaps.add((Map<String, Object>) o);
+                    }
+                    setRpms(mapsToRpms(rpmMaps));
+                    break;
+                case Constants.listArchives:
+                    final List<Map<String, Object>> archiveMaps = new ArrayList<>(list.size());
+                    for (Object o : list) {
+                        archiveMaps.add((Map<String, Object>) o);
+                    }
+                    setArchives(mapsToArchives(archiveMaps));
+                    break;
+                case Constants.listTags:
+                    final Set<String> tags = new HashSet<>();
+                    for (Object o : list) {
+                        final Map tag = (Map) o;
+                        tags.add((String) tag.get(Constants.name));
+                    }
+                    setTags(tags);
+                    break;
+            }
+        }
+        return build();
+    }
 
-	public XmlRpcResponse build(Object object) {
-		if (object instanceof Integer) {
-			setPackageId((Integer) object);
-		}
-		return build();
-	}
+    public XmlRpcResponse build(Object object) {
+        if (object instanceof Integer) {
+            setPackageId((Integer) object);
+        }
+        return build();
+    }
 
-	private List<Build> mapsToBuilds(List<Map<String, Object>> maps) {
-		if (maps == null) {
-			return Collections.emptyList();
-		}
-		final List<Build> builds = new ArrayList<>(maps.size());
-		for (Map<String, Object> map : maps) {
-			builds.add(mapToBuild(map));
-		}
-		return builds;
-	}
+    private List<Build> mapsToBuilds(List<Map<String, Object>> maps) {
+        if (maps == null) {
+            return Collections.emptyList();
+        }
+        final List<Build> builds = new ArrayList<>(maps.size());
+        for (Map<String, Object> map : maps) {
+            builds.add(mapToBuild(map));
+        }
+        return builds;
+    }
 
 	private Build mapToBuild(Map<String, Object> map) {
 		return new Build(
-				(Integer) map.get(Constants.build_id),
-				(String) map.get(Constants.name),
-				(String) map.get(Constants.version),
-				(String) map.get(Constants.release),
-				(String) map.get(Constants.nvr),
-				(String) map.get(Constants.completion_time),
-				null,
-				null,
-				null
+		        (Integer) map.get(Constants.build_id),
+                (String) map.get(Constants.name),
+                (String) map.get(Constants.version),
+                (String) map.get(Constants.release),
+                (String) map.get(Constants.nvr),
+                (String) map.get(Constants.completion_time),
+                null,
+                null,
+                null
 		);
 	}
 
-	private List<RPM> mapsToRpms(List<Map<String, Object>> rpmMaps) {
-		if (rpmMaps == null) {
-			return Collections.emptyList();
-		}
-		final List<RPM> rpms = new ArrayList<>(rpmMaps.size());
-		for (Map<String, Object> map : rpmMaps) {
-			rpms.add(mapToRpm(map));
-		}
-		return rpms;
-	}
+    private List<RPM> mapsToRpms(List<Map<String, Object>> rpmMaps) {
+        if (rpmMaps == null) {
+            return Collections.emptyList();
+        }
+        final List<RPM> rpms = new ArrayList<>(rpmMaps.size());
+        for (Map<String, Object> map : rpmMaps) {
+            rpms.add(mapToRpm(map));
+        }
+        return rpms;
+    }
 
-	private List<String> mapsToArchives(List<Map<String, Object>> archiveMaps) {
-		if (archiveMaps == null) {
-			return Collections.emptyList();
-		}
-		final List<String> archives = new ArrayList<>(archiveMaps.size());
-		for (Map<String, Object> map : archiveMaps) {
-			archives.add(mapToArchive(map));
-		}
-		return archives;
-	}
+    private List<String> mapsToArchives(List<Map<String, Object>> archiveMaps) {
+        if (archiveMaps == null) {
+            return Collections.emptyList();
+        }
+        final List<String> archives = new ArrayList<>(archiveMaps.size());
+        for (Map<String, Object> map : archiveMaps) {
+            archives.add(mapToArchive(map));
+        }
+        return archives;
+    }
 
-	private String mapToArchive(Map<String, Object> map) {
-		return (String) map.get(Constants.filename);
-	}
+    private String mapToArchive(Map<String, Object> map) {
+        return (String) map.get(Constants.filename);
+    }
 
-	private RPM mapToRpm(Map<String, Object> map) {
-		return new RPM(
-				(String) map.get(Constants.name),
-				(String) map.get(Constants.version),
-				(String) map.get(Constants.release),
-				(String) map.get(Constants.nvr),
-				(String) map.get(Constants.arch),
-				(String) map.get(Constants.filename)
-		);
-	}
+    private RPM mapToRpm(Map<String, Object> map) {
+        return new RPM(
+                (String) map.get(Constants.name),
+                (String) map.get(Constants.version),
+                (String) map.get(Constants.release),
+                (String) map.get(Constants.nvr),
+                (String) map.get(Constants.arch),
+                (String) map.get(Constants.filename)
+        );
+    }
 }


### PR DESCRIPTION
… classes (List of Build, Set of Strings(tags))

XmlRpcRequestParams and XmlRpcRequest serve as wrapper classes, they get converted to array of maps of objects and vice versa