### PR TITLE
Fix config directory "projects" to "jdkProjects" to match app tab names

### DIFF
--- a/fake-koji/src/main/java/org/fakekoji/jobmanager/ConfigManager.java
+++ b/fake-koji/src/main/java/org/fakekoji/jobmanager/ConfigManager.java
@@ -18,7 +18,7 @@ public class ConfigManager {
     private final static String PRODUCTS = "products";
     private final static String TASK_VARIANTS = "taskVariants";
     private final static String PLATFORMS = "platforms";
-    private final static String PROJECTS = "projects";
+    private final static String PROJECTS = "jdkProjects";
     private final static String JDK_TEST_PROJECTS = "jdkTestProjects";
     private final static String TASKS = "tasks";
 

--- a/fake-koji/src/test/java/org/fakekoji/DataGenerator.java
+++ b/fake-koji/src/test/java/org/fakekoji/DataGenerator.java
@@ -979,7 +979,7 @@ public class DataGenerator {
         final File buildProviders = Paths.get(root, "buildProviders").toFile();
         final File platformProviders = Paths.get(root, "platformProviders").toFile();
         final File taskVariantCategories = Paths.get(root, "taskVariants").toFile();
-        final File jdkProjects = Paths.get(root, "projects").toFile();
+        final File jdkProjects = Paths.get(root, "jdkProjects").toFile();
         final File jdkTestProjects = Paths.get(root, "jdkTestProjects").toFile();
 
         final List<File> configFiles = Arrays.asList(


### PR DESCRIPTION
Avoids confusion when looking for the config files

Fixes issue #82: Config directories should match gui tab names