### PR TITLE
Added support for containers

### DIFF
--- a/jenkins-scm-koji-plugin/src/main/java/hudson/plugins/scm/koji/client/KojiBuildDownloader.java
+++ b/jenkins-scm-koji-plugin/src/main/java/hudson/plugins/scm/koji/client/KojiBuildDownloader.java
@@ -1,9 +1,7 @@
 package hudson.plugins.scm.koji.client;
 
 import hudson.FilePath;
-import hudson.model.Job;
 import hudson.model.TaskListener;
-import hudson.plugins.scm.koji.BuildsSerializer;
 import hudson.plugins.scm.koji.model.Build;
 import hudson.plugins.scm.koji.model.KojiBuildDownloadResult;
 import hudson.plugins.scm.koji.model.KojiScmConfig;
@@ -24,7 +22,6 @@ import java.util.Date;
 
 import org.jenkinsci.remoting.RoleChecker;
 
-import static hudson.plugins.scm.koji.Constants.BUILD_XML;
 
 
 import org.slf4j.Logger;
@@ -281,7 +278,7 @@ public class KojiBuildDownloader implements FilePath.FileCallable<KojiBuildDownl
         sb.append(build.getName()).append('/')
         .append(build.getVersion()).append('/')
         .append(build.getRelease()).append('/')
-        .append(rpm.getArch()).append('/')
+        .append(addArch(rpm)).append('/')
         .append(rpm.getFilename(suffix));
         return sb.toString();
     }
@@ -392,4 +389,16 @@ public class KojiBuildDownloader implements FilePath.FileCallable<KojiBuildDownl
             huc.disconnect();
         }
     }
+
+    private static String addArch(RPM rpm) {
+        //it may happen. that this will be necessary to be configurable in koji plugin
+        //is container checkbox?
+        if (BuildMatcher.isRpmContainer(rpm)) {
+            return "images";
+        } else {
+            return rpm.getArch();
+        }
+    }
+
+
 }


### PR DESCRIPTION
Iitially I was only about to remove:
```            
            final List<String> supportedArches = new ArrayList<>(1);
            supportedArches.add("win");
```
But then I realised that all-arches x single arch is not at all implemented for archives
In addition,  all those types of archives differs in both xml response and in file handling.

When the arch x images for url composition appered, I decided to go with the if-container switch rather. That is currently strgthforward, but if it will go wild. then  isContainer switch will need to appear into job configuration/


Btw, the trick with arhitecutreed "detection" should be aplicable also for windows archives with minimal changes. If needed..ever...
