### PR TITLE
Container support master

### DIFF
--- a/fake-koji/pom.xml
+++ b/fake-koji/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>fake-koji</groupId>
         <artifactId>koji-scm</artifactId>
-        <version>0.2-SNAPSHOT</version>
+        <version>2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>fake-koji</artifactId>

--- a/jenkins-scm-koji-plugin/pom.xml
+++ b/jenkins-scm-koji-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>fake-koji</groupId>
         <artifactId>koji-scm</artifactId>
-        <version>0.2-SNAPSHOT</version>
+        <version>2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jenkins-scm-koji-plugin</artifactId>

--- a/jenkins-scm-koji-plugin/src/main/java/hudson/plugins/scm/koji/client/KojiBuildDownloader.java
+++ b/jenkins-scm-koji-plugin/src/main/java/hudson/plugins/scm/koji/client/KojiBuildDownloader.java
@@ -350,7 +350,7 @@ public class KojiBuildDownloader implements FilePath.FileCallable<KojiBuildDownl
         sb.append(build.getName()).append('/')
         .append(build.getVersion()).append('/')
         .append(build.getRelease()).append('/')
-        .append(rpm.getArch()).append('/')
+        .append(addArch(rpm)).append('/')
         .append(rpm.getFilename(suffix));
         return sb.toString();
     }
@@ -461,4 +461,16 @@ public class KojiBuildDownloader implements FilePath.FileCallable<KojiBuildDownl
             huc.disconnect();
         }
     }
+
+    private static String addArch(RPM rpm) {
+        //it may happen. that this will be necessary to be configurable in koji plugin
+        //is container checkbox?
+        if (KojiBuildMatcher.isRpmContainer(rpm)) {
+            return "images";
+        } else {
+            return rpm.getArch();
+        }
+    }
+
+
 }

--- a/jenkins-scm-koji-plugin/src/main/java/hudson/plugins/scm/koji/client/KojiBuildMatcher.java
+++ b/jenkins-scm-koji-plugin/src/main/java/hudson/plugins/scm/koji/client/KojiBuildMatcher.java
@@ -150,54 +150,66 @@ class KojiBuildMatcher extends BuildMatcher {
             //for contaiers, we use different approach(because they havee arch in name only), we list all the archives, and include only those of arch (all if no arch is specified)
             //luckily for us, they are mess.arch.tar.gz
             if (archs == null || archs.isEmpty()) {
-                for (String archiveName : archivefilenames) {
+                addAllContainerArchives(archivefilenames, archives, build);
+            } else {
+                addSelectedArchesContainers(archivefilenames, archives, build);
+            }
+        } else {
+            addWindowsArchives(archivefilenames, archives, build);
+        }
+        return archives;
+    }
+
+    private void addWindowsArchives(final List<String> archivefilenames, final List<RPM> archives, Build build) {
+        final List<String> supportedArches = new ArrayList<>(1);
+        supportedArches.add("win");
+        for (String archiveName : archivefilenames) {
+            //warning! this do not support empty arches  field!
+            //and windows archives are arcehd in the xml response
+            //to list all, similar hack like in containers wouldbeneeded
+            for (String arch : archs) {
+                if (supportedArches.contains(arch)) {
                     archives.add(new RPM(
                             build.getName(),
                             build.getVersion(),
                             build.getRelease(),
                             archiveName,
-                            /*Is this necessary at all?*/ deductArchFromImage(archiveName),
+                            arch,
                             archiveName
                     ));
                 }
-            } else {
-                for (String archiveName : archivefilenames) {
-                    for (String arch : archs) {
-                        if (archiveName.contains("." + arch + ".")) {
-                            archives.add(new RPM(
-                                    build.getName(),
-                                    build.getVersion(),
-                                    build.getRelease(),
-                                    archiveName,
-                                    arch,
-                                    archiveName
-                            ));
-                        }
-                    }
-                }
             }
-        } else {
-            final List<String> supportedArches = new ArrayList<>(1);
-            supportedArches.add("win");
-            for (String archiveName : archivefilenames) {
-                //warning! this do not support empty arches  field!
-                //and windows archives are arcehd in the xml response
-                //to list all, similar hack like in containers wouldbeneeded
-                for (String arch : archs) {
-                    if (supportedArches.contains(arch)) {
-                        archives.add(new RPM(
-                                build.getName(),
-                                build.getVersion(),
-                                build.getRelease(),
-                                archiveName,
-                                arch,
-                                archiveName
-                        ));
-                    }
+        }
+    }
+
+    private void addSelectedArchesContainers(final List<String> archivefilenames, final List<RPM> archives, Build build) {
+        for (String archiveName : archivefilenames) {
+            for (String arch : archs) {
+                if (archiveName.contains("." + arch + ".")) {
+                    archives.add(new RPM(
+                            build.getName(),
+                            build.getVersion(),
+                            build.getRelease(),
+                            archiveName,
+                            arch,
+                            archiveName
+                    ));
                 }
             }
         }
-        return archives;
+    }
+
+    private void addAllContainerArchives(final List<String> archivefilenames, final List<RPM> archives, Build build) {
+        for (String archiveName : archivefilenames) {
+            archives.add(new RPM(
+                    build.getName(),
+                    build.getVersion(),
+                    build.getRelease(),
+                    archiveName,
+                    /*Is this necessary at all?*/ deductArchFromImage(archiveName),
+                    archiveName
+            ));
+        }
     }
 
     private static List<String> composeArchList(String arch) {

--- a/koji-scm-lib/pom.xml
+++ b/koji-scm-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>fake-koji</groupId>
         <artifactId>koji-scm</artifactId>
-        <version>0.2-SNAPSHOT</version>
+        <version>2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>koji-scm-lib</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>fake-koji</groupId>
     <artifactId>koji-scm</artifactId>
-    <version>0.2-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Koji SCM</name>


### PR DESCRIPTION
Iitially I was only about to remove:
```            
            final List<String> supportedArches = new ArrayList<>(1);
            supportedArches.add("win");
```
But then I realised that all-arches x single arch is not at all implemented for archives
In addition,  all those types of archives differs in both xml response and in file handling.

When the arch x images for url composition appered, I decided to go with the if-container switch rather. That is currently strgthforward, but if it will go wild. then  isContainer switch will need to appear into job configuration/


Btw, the trick with arhitecutreed "detection" should be aplicable also for windows archives with minimal changes. If needed..ever...
