### PR TITLE
Package filtering logging2

### DIFF
--- a/jenkins-scm-koji-plugin/src/main/java/hudson/plugins/scm/koji/client/KojiBuildDownloader.java
+++ b/jenkins-scm-koji-plugin/src/main/java/hudson/plugins/scm/koji/client/KojiBuildDownloader.java
@@ -48,7 +48,7 @@ import org.slf4j.LoggerFactory;
 
 import jakarta.xml.bind.DatatypeConverter;
 
-public class KojiBuildDownloader implements FilePath.FileCallable<KojiBuildDownloadResult>, LoggerHelp {
+public class KojiBuildDownloader implements FilePath.FileCallable<KojiBuildDownloadResult>, LoggerHelp, TaskListenerLogTransporter {
 
     private static final Logger LOG = LoggerFactory.getLogger(KojiSCM.class);
     private static final int MAX_REDIRECTIONS = 10;
@@ -276,11 +276,12 @@ public class KojiBuildDownloader implements FilePath.FileCallable<KojiBuildDownl
         Predicate<RPM> nvrPredicate = i -> true;
         final String subpackageBlacklist = realKojiXmlRpcApi.getSubpackageBlacklist();
         if (subpackageBlacklist != null && !subpackageBlacklist.isEmpty()) {
-            GlobPredicate glob = new GlobPredicate(subpackageBlacklist);
+            GlobPredicate glob = new GlobPredicate(subpackageBlacklist, this);
             nvrPredicate = (RPM rpm) -> {
                 if (rpm.getArch().equals("src")) {
                     return true;
                 } else {
+                    log("[KojiSCM] Matching blacklist ...");
                     return !glob.test(rpm.getNvr());
                 }
             };
@@ -289,15 +290,18 @@ public class KojiBuildDownloader implements FilePath.FileCallable<KojiBuildDownl
         Predicate<RPM> whitelistPredicate = i -> true;
         final String subpackageWhitelist = realKojiXmlRpcApi.getSubpackageWhitelist();
         if (subpackageWhitelist != null && !subpackageWhitelist.isEmpty()) {
-            GlobPredicate glob = new GlobPredicate(subpackageWhitelist);
+            GlobPredicate glob = new GlobPredicate(subpackageWhitelist, this);
             whitelistPredicate = (RPM rpm) -> {
                 if (rpm.getArch().equals("src")){
                     return true;
                 } else {
+                    log("[KojiSCM] Matching whitelist ...");
                     return glob.test(rpm.getNvr());
                 }
             };
         }
+
+        String allPackages = build.getRpms().stream().map(a->a.toString()).collect(Collectors.joining(","));
 
         List<String> l = build.getRpms()
                 .stream()
@@ -310,9 +314,9 @@ public class KojiBuildDownloader implements FilePath.FileCallable<KojiBuildDownl
         int dwnldedFiles = l.size();
         if (dwnldedFiles == 0) {
             if (rpmsInBuildXml == 0) {
-                log("Warning, nothing downloaded, but looks like  nothing shoudl be.");
+                log("Warning, nothing downloaded, but looks like  nothing should be.");
             } else {
-                log("WARNING, nothing downloaded, but shoudl be (" + rpmsInBuildXml + "). Maybe bad exclude packages?");
+                log("WARNING, nothing downloaded, but should be (" + rpmsInBuildXml + "). Maybe bad exclude packages?");
             }
         }
         return l;
@@ -547,5 +551,8 @@ public class KojiBuildDownloader implements FilePath.FileCallable<KojiBuildDownl
         }
     }
 
-
+    @Override
+    public void println(String s) {
+        currentListener.getLogger().println(s);
+    }
 }

--- a/jenkins-scm-koji-plugin/src/main/java/hudson/plugins/scm/koji/client/KojiBuildDownloader.java
+++ b/jenkins-scm-koji-plugin/src/main/java/hudson/plugins/scm/koji/client/KojiBuildDownloader.java
@@ -301,8 +301,6 @@ public class KojiBuildDownloader implements FilePath.FileCallable<KojiBuildDownl
             };
         }
 
-        String allPackages = build.getRpms().stream().map(a->a.toString()).collect(Collectors.joining(","));
-
         List<String> l = build.getRpms()
                 .stream()
                 .filter(nvrPredicate)

--- a/jenkins-scm-koji-plugin/src/main/java/hudson/plugins/scm/koji/client/KojiBuildMatcher.java
+++ b/jenkins-scm-koji-plugin/src/main/java/hudson/plugins/scm/koji/client/KojiBuildMatcher.java
@@ -42,7 +42,7 @@ class KojiBuildMatcher extends BuildMatcher {
             RealKojiXmlRpcApi kojiXmlRpcApi
     ) {
         super(kojiBuildProviders, notProcessedNvrPredicate, maxBuilds);
-        this.tagPredicate = new GlobPredicate(kojiXmlRpcApi.getTag());
+        this.tagPredicate = new GlobPredicate(kojiXmlRpcApi.getTag(), null);
         this.pkgName = kojiXmlRpcApi.getPackageName();
         this.archs = composeArchList(kojiXmlRpcApi.getArch());
     }

--- a/koji-scm-lib/src/main/java/hudson/plugins/scm/koji/client/GlobPredicate.java
+++ b/koji-scm-lib/src/main/java/hudson/plugins/scm/koji/client/GlobPredicate.java
@@ -1,5 +1,7 @@
 package hudson.plugins.scm.koji.client;
 
+import org.slf4j.Logger;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -9,11 +11,16 @@ import java.util.regex.Pattern;
 public class GlobPredicate implements Predicate<CharSequence>, java.io.Serializable {
 
     private final List<Pattern> globPatterns;
+    private final transient TaskListenerLogTransporter log;
+    private static final long serialVersionUID = -402287815488043482L;
 
-    public GlobPredicate(String globExpr) {
+    public GlobPredicate(String globExpr, TaskListenerLogTransporter logger) {
         if (globExpr == null) {
             globExpr = "";
         }
+
+        log = logger;
+
         String[] origs = globExpr.split("\\s+");
         List<Pattern> tofinal = new ArrayList<>(origs.length);
         for (int i = 0; i < origs.length; i++) {
@@ -28,15 +35,22 @@ public class GlobPredicate implements Predicate<CharSequence>, java.io.Serializa
     @Override
     public boolean test(CharSequence input) {
         if (globPatterns.isEmpty()) {
+            logMessage("[KojiSCM] matched: " + input + " because of globPattern is empty");
             return true;
         }
         for (Pattern globPattern : globPatterns) {
             if (globPattern.matcher(input).matches()) {
+                logMessage("[KojiSCM] matched: " + input + " because of globPattern: " + globPattern);
                 return true;
             }
         }
+        logMessage("[KojiSCM] not matched: " + input + " because this globPattern didn't match anything.");
         return false;
-
     }
 
+    private void logMessage(String message) {
+        if(log != null) {
+           log.println(message);
+        }
+    }
 }

--- a/koji-scm-lib/src/main/java/hudson/plugins/scm/koji/client/GlobPredicate.java
+++ b/koji-scm-lib/src/main/java/hudson/plugins/scm/koji/client/GlobPredicate.java
@@ -1,7 +1,5 @@
 package hudson.plugins.scm.koji.client;
 
-import org.slf4j.Logger;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;

--- a/koji-scm-lib/src/main/java/hudson/plugins/scm/koji/client/TaskListenerLogTransporter.java
+++ b/koji-scm-lib/src/main/java/hudson/plugins/scm/koji/client/TaskListenerLogTransporter.java
@@ -1,0 +1,5 @@
+package hudson.plugins.scm.koji.client;
+
+public interface TaskListenerLogTransporter {
+    public void println(String s);
+}

--- a/koji-scm-lib/src/test/java/hudson/plugins/scm/koji/client/GlobPredicateTest.java
+++ b/koji-scm-lib/src/test/java/hudson/plugins/scm/koji/client/GlobPredicateTest.java
@@ -35,14 +35,14 @@ public class GlobPredicateTest {
     public void testSimpleAsterics() {
         String glob = "f23-updates.*";
         String input = "f23-updates-candidate";
-        assertTrue(new GlobPredicate(glob).test(input));
+        assertTrue(new GlobPredicate(glob, null).test(input));
     }
     
     @Test
     public void nothingMatchesAll() {
         String glob = "";
         String input = "whatever";
-        assertTrue(new GlobPredicate(glob).test(input));
+        assertTrue(new GlobPredicate(glob, null).test(input));
     }
 
     @Test
@@ -51,9 +51,9 @@ public class GlobPredicateTest {
         String input1 = "no_Build-f23-tag";
         String input2 = "x86_64.Built-f23-tag";
         String input3 = "i686.Built-f23-tag";
-        assertTrue(new GlobPredicate(glob).test(input1));
-        assertTrue(new GlobPredicate(glob).test(input2));
-        assertFalse(new GlobPredicate(glob).test(input3));
+        assertTrue(new GlobPredicate(glob, null).test(input1));
+        assertTrue(new GlobPredicate(glob, null).test(input2));
+        assertFalse(new GlobPredicate(glob, null).test(input3));
     }
 
     private final List<String> inputs = Arrays.asList(
@@ -76,13 +76,13 @@ public class GlobPredicateTest {
     public void testCurlyBrackets() {
         //see difference, debuginfo will be included
         String glob = ".*debug-.*   .*accessibility.*   .*src.*   .*demo.*  ";
-        GlobPredicate predicate = new GlobPredicate(glob);
+        GlobPredicate predicate = new GlobPredicate(glob, null);
         assertEquals(9, inputs.stream().filter(predicate).count());
     }
 
     public void testCurlyBracketsAndNegation() {
         String glob = "   .*debug.*   .*accessibility.*   .*src.*   .*demo.* ";
-        GlobPredicate predicate = new GlobPredicate(glob);
+        GlobPredicate predicate = new GlobPredicate(glob, null);
         assertEquals(3, inputs.stream().filter(predicate.negate()).count());
     }
 


### PR DESCRIPTION
Add more detailed logging useful for debugging of download issues.

Sample output

[KojiSCM][rcap.brq.csb] [KojiSCM] Matching blacklist ...
[KojiSCM] not matched: java-1.8.0-openjdk-1.8.0.322-2.b06.dev.redhat.windows.x86.msibecause this globPattern didn't match anything.
[KojiSCM][rcap.brq.csb] [KojiSCM] Matching whitelist ...
[KojiSCM] not matched: java-1.8.0-openjdk-1.8.0.322-2.b06.dev.redhat.windows.x86.msibecause this globPattern didn't match anything.
[KojiSCM][rcap.brq.csb] [KojiSCM] Matching blacklist ...
[KojiSCM] matched: java-1.8.0-openjdk-1.8.0.322-2.b06.dev.redhat.windows.x86.zip because of globPattern: .*\.zip$
[KojiSCM][rcap.brq.csb] [KojiSCM] Matching blacklist ...
[KojiSCM] matched: java-1.8.0-openjdk-jre-1.8.0.322-2.b06.dev.redhat.windows.x86.zip because of globPattern: .*\.zip$
[KojiSCM][rcap.brq.csb] [KojiSCM] Matching blacklist ...
[KojiSCM] not matched: java-1.8.0-openjdk-1.8.0.322-2.b06.dev.redhat.windows.x86_64.msibecause this globPattern didn't match anything.
[KojiSCM][rcap.brq.csb] [KojiSCM] Matching whitelist ...
[KojiSCM] matched: java-1.8.0-openjdk-1.8.0.322-2.b06.dev.redhat.windows.x86_64.msi because of globPattern: .*.x86_64.msi$
[KojiSCM][rcap.brq.csb] rcap.brq.csb
[KojiSCM][rcap.brq.csb] Wed Feb 02 14:22:17 CET 2022
[KojiSCM][rcap.brq.csb] Downloading: : ....java-1.8.0-openjdk-1.8.0.322-2.b06.dev.redhat.windows.x86_64.msi