### PR TITLE
Update pom file version of the Jenkins parent plugin to 4.87 to suppo…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.65</version>
+        <version>4.87</version>
     </parent>
 
     <groupId>fake-koji</groupId>


### PR DESCRIPTION
…rt JDK 21.

Built on vagrant vm using the following  command:
mvn install -Dheadless -pl fake-koji:koji-scm -am --batch-mode -Djava.net.preferIPv4Stack=true -Dmaven.repo.local=/tmp/artifacts/m2  package

$ mvn --version
Apache Maven 3.9.6 (Red Hat 3.9.6-6)
Maven home: /usr/share/maven
Java version: 21.0.4, vendor: Red Hat, Inc., runtime: /usr/lib/jvm/java-21-openjdk-21.0.4.0.7-2.fc40.x86_64
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "6.8.0-63.fc40.1.x86_64", arch: "amd64", family: "unix"